### PR TITLE
FEAT: 매거진 검색 기능(필터 추가)

### DIFF
--- a/src/main/java/com/AcovueMagazine/Magazine/Controller/MagazineController.java
+++ b/src/main/java/com/AcovueMagazine/Magazine/Controller/MagazineController.java
@@ -21,7 +21,19 @@ public class MagazineController {
 
     private final MagazineService magazineService;
 
-    // 매거진 검색
+    /**
+     * Searches magazines matching the optional criteria and returns the results wrapped in an ApiResponse.
+     *
+     * <p>Searches by an optional text keyword and an optional date-time range (start/end). Date-time
+     * parameters are parsed using ISO-8601 date-time format. Results are ordered by creation date;
+     * set {@code newestFirst=false} to return oldest-first.</p>
+     *
+     * @param keyword     optional text to match against magazine fields (title/content/etc.)
+     * @param start       optional inclusive start of the date-time range (ISO-8601)
+     * @param end         optional inclusive end of the date-time range (ISO-8601)
+     * @param newestFirst if true (default) sort results newest-first; if false sort oldest-first
+     * @return an ApiResponse whose data is a List of MagazineResDTO matching the search criteria
+     */
     @GetMapping("/search")
     public ApiResponse<?> searchMagazine(
             @RequestParam(required = false) String keyword,
@@ -33,7 +45,11 @@ public class MagazineController {
         return ResponseUtil.successResponse("매거진 검색을 성공적으로 수행하였습니다.", searchResults).getBody();
     }
 
-    // 매거진 조회
+    /**
+     * Retrieves all magazines and wraps them in a success ApiResponse.
+     *
+     * @return an ApiResponse containing a List of MagazineResDTO on success
+     */
     @GetMapping("/find/all")
     public ApiResponse<?> getMagazineList() {
         List<MagazineResDTO> magazines = magazineService.getAllMagazines();

--- a/src/main/java/com/AcovueMagazine/Magazine/Repository/MagazineRepository.java
+++ b/src/main/java/com/AcovueMagazine/Magazine/Repository/MagazineRepository.java
@@ -11,6 +11,13 @@ import java.util.List;
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
 
-    List<Magazine> findAll(Specification<Magazine> spec, Sort sort);
+    /**
+ * Retrieves all Magazine entities that match the given specification, applying the provided sort order.
+ *
+ * @param spec specification defining filtering criteria; may be {@code null} to match all entities
+ * @param sort sort order to apply to the results; may be {@code null} or unsorted
+ * @return a list of Magazine entities matching the specification in the requested order (empty if none)
+ */
+List<Magazine> findAll(Specification<Magazine> spec, Sort sort);
 
 }

--- a/src/main/java/com/AcovueMagazine/Magazine/Service/MagazineService.java
+++ b/src/main/java/com/AcovueMagazine/Magazine/Service/MagazineService.java
@@ -110,7 +110,17 @@ public class MagazineService {
         return MagazineResDTO.fromEntity(magazine);
     }
 
-    // 매거진 삭제 기능
+    /**
+     * Deletes a magazine by ID if the requesting user is authorized and returns the deleted magazine as a DTO.
+     *
+     * If the current user is the magazine owner or has the ADMIN role, the magazine is removed from the repository.
+     *
+     * @param magazineId   ID of the magazine to delete
+     * @param currentUsers the user performing the deletion; used for authorization (must be owner or ADMIN)
+     * @return a MagazineResDTO representing the deleted magazine
+     * @throws javax.persistence.EntityNotFoundException if no magazine exists with the given ID
+     * @throws org.springframework.security.access.AccessDeniedException if the requesting user is not authorized to delete the magazine
+     */
     @Transactional
     public MagazineResDTO deleteMagazine(Long magazineId, Users currentUsers) {
         Magazine magazine = magazineRepository.findById(magazineId)
@@ -128,6 +138,19 @@ public class MagazineService {
         return MagazineResDTO.fromEntity(magazine);
     }
 
+    /**
+     * Searches magazines by keyword and optional registration-date range, returning DTOs ordered by registration date.
+     *
+     * The search matches the keyword against title or content and filters by registration date between
+     * `start` and `end` (if provided). Results are sorted by `regDate` descending when `newestFirst` is true,
+     * otherwise ascending.
+     *
+     * @param keyword     text to match against magazine title or content; null or empty matches all
+     * @param start       start of the registration-date range (inclusive); may be null to omit lower bound
+     * @param end         end of the registration-date range (inclusive); may be null to omit upper bound
+     * @param newestFirst if true, sort results by `regDate` descending; if false, sort ascending
+     * @return a list of MagazineResDTOs representing matched magazines (may be empty)
+     */
     public List<MagazineResDTO> searchMagzine(String keyword, LocalDateTime start, LocalDateTime end, boolean newestFirst) {
         Specification<Magazine> spec = Specification
                 .where(MagazineSpecification.titleOrContentContains(keyword))

--- a/src/main/java/com/AcovueMagazine/Magazine/Specification/MagazineSpecification.java
+++ b/src/main/java/com/AcovueMagazine/Magazine/Specification/MagazineSpecification.java
@@ -7,6 +7,14 @@ import java.time.LocalDateTime;
 
 public class MagazineSpecification {
 
+    /**
+     * Creates a Specification that matches magazines whose title or content contains the given keyword (case-insensitive).
+     *
+     * If {@code keyword} is {@code null} or empty, this method returns {@code null} (no predicate).
+     *
+     * @param keyword substring to search for in {@code magazineTitle} or {@code magazineContent}; case is ignored
+     * @return a {@code Specification<Magazine>} performing a case-insensitive LIKE on title or content, or {@code null} when no predicate should be applied
+     */
     public static Specification<Magazine> titleOrContentContains(String keyword){
         return (root, query, builder) -> {
             if (keyword == null || keyword.isEmpty()) return null;
@@ -17,6 +25,18 @@ public class MagazineSpecification {
         };
     }
 
+    /**
+     * Builds a JPA Specification that filters Magazine.regDate to the given range.
+     *
+     * If both `start` and `end` are null, no predicate is produced (the method returns null).
+     * If both are non-null, the predicate matches records with `regDate` between `start` and `end` (inclusive).
+     * If only `start` is non-null, the predicate matches records with `regDate` >= `start`.
+     * If only `end` is non-null, the predicate matches records with `regDate` <= `end`.
+     *
+     * @param start the lower bound of the registration date range (inclusive); may be null
+     * @param end   the upper bound of the registration date range (inclusive); may be null
+     * @return a Specification<Magazine> representing the date-range predicate, or null if neither bound is provided
+     */
     public static Specification<Magazine> regDateBetween(LocalDateTime start, LocalDateTime end) {
         return(root, query, builder) -> {
             if(start == null && end == null) return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a magazine search endpoint with flexible filters:
    - Keyword search across titles and content
    - Optional date range filtering (ISO date-time)
    - Configurable sort order (newest-first)
  * Returns a structured list of matching magazines for easier discovery

* **Chores**
  * Standardized /find/all to return a consistent success-wrapped API response
<!-- end of auto-generated comment: release notes by coderabbit.ai -->