### PR TITLE
FEAT: 댓글 좋아요 개수 조회

### DIFF
--- a/src/main/java/com/AcovueMagazine/Like/Controller/LikeController.java
+++ b/src/main/java/com/AcovueMagazine/Like/Controller/LikeController.java
@@ -2,6 +2,7 @@ package com.AcovueMagazine.Like.Controller;
 
 import com.AcovueMagazine.Common.Response.ApiResponse;
 import com.AcovueMagazine.Common.Response.ResponseUtil;
+import com.AcovueMagazine.Like.DTO.CommentLikeCountResDTO;
 import com.AcovueMagazine.Like.DTO.CommentLikeResDTO;
 import com.AcovueMagazine.Like.DTO.MagazineLikeResDTO;
 import com.AcovueMagazine.Like.Service.LikeService;
@@ -31,6 +32,15 @@ public class LikeController {
         CommentLikeResDTO like = likeService.toggleCommentLike(commentSeq, userSeq);
 
         return ResponseUtil.successResponse("댓글 좋아요를 성공적으로 등록/삭제하였습니다.", like).getBody();
+    }
+
+    // 댓글 조아요 조회 기능
+    @GetMapping("comment/{commentSeq}")
+    public ApiResponse<?> getCommentLike(@PathVariable Long commentSeq){
+
+        CommentLikeCountResDTO commentLikeCount = likeService.commentLikeCount(commentSeq);
+
+        return ResponseUtil.successResponse("댓글 좋아요를 성공적으로 조회하였습니다.", commentLikeCount).getBody();
     }
 
 

--- a/src/main/java/com/AcovueMagazine/Like/DTO/CommentLikeCountResDTO.java
+++ b/src/main/java/com/AcovueMagazine/Like/DTO/CommentLikeCountResDTO.java
@@ -1,0 +1,16 @@
+package com.AcovueMagazine.Like.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentLikeCountResDTO {
+
+    private Long commentSeq;
+    private Long likeCount;
+
+    public static CommentLikeCountResDTO from(Long commentSeq,Long likeCount){
+        return new CommentLikeCountResDTO(commentSeq,likeCount);
+    }
+}

--- a/src/main/java/com/AcovueMagazine/Like/DTO/CommentLikeResDTO.java
+++ b/src/main/java/com/AcovueMagazine/Like/DTO/CommentLikeResDTO.java
@@ -1,5 +1,6 @@
 package com.AcovueMagazine.Like.DTO;
 
+import com.AcovueMagazine.Comment.Entity.Comment;
 import com.AcovueMagazine.Like.Entity.CommentLike;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,7 @@ public class CommentLikeResDTO {
     private Long userSeq;
     private Long commentSeq;
     private boolean liked;
+
 
     public static CommentLikeResDTO fromEntity(CommentLike like) {
         if (like == null) {

--- a/src/main/java/com/AcovueMagazine/Like/Respository/CommentLikeRepository.java
+++ b/src/main/java/com/AcovueMagazine/Like/Respository/CommentLikeRepository.java
@@ -12,4 +12,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 
     // 유저 + 댓글로 좋아요 있는지 검증
     Optional<CommentLike> findByUserAndComment(Users user, Comment comment);
+
+    Long countByComment_CommentSeq(Long commentSeq);
 }

--- a/src/main/java/com/AcovueMagazine/Like/Service/LikeService.java
+++ b/src/main/java/com/AcovueMagazine/Like/Service/LikeService.java
@@ -3,6 +3,7 @@ package com.AcovueMagazine.Like.Service;
 import com.AcovueMagazine.Comment.DTO.CommentResDTO;
 import com.AcovueMagazine.Comment.Entity.Comment;
 import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Like.DTO.CommentLikeCountResDTO;
 import com.AcovueMagazine.Like.DTO.CommentLikeResDTO;
 import com.AcovueMagazine.Like.DTO.MagazineLikeResDTO;
 import com.AcovueMagazine.Like.Entity.CommentLike;
@@ -80,5 +81,17 @@ public class LikeService {
         }
 
         return CommentLikeResDTO.fromEntity(like);
+    }
+
+    // 댓글 좋아요 조회 기능
+    @Transactional
+    public CommentLikeCountResDTO commentLikeCount(Long commentSeq) {
+
+        Comment comment = commentRepository.findById(commentSeq)
+                .orElseThrow(() -> new EntityNotFoundException("해당 댓글을 찾을 수 없습니다." + commentSeq));
+
+        Long likeCount = commentLikeRepository.countByComment_CommentSeq(commentSeq);
+
+        return CommentLikeCountResDTO.from(commentSeq, likeCount);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 댓글 좋아요 수 조회 기능 추가: /api/like/comment/{commentSeq} (GET) 호출로 특정 댓글의 총 좋아요 개수를 확인할 수 있습니다.
  * 응답에는 댓글 식별자와 좋아요 개수가 포함되어, 클라이언트에서 표시 및 통계 처리에 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->