### PR TITLE
FIX : redis 주소 변경 localhost->127.0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bin/
 
 ### env ###
 .env
+
+### github ###
+.github

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: 127.0.0.1
       port: 6379
       password: "" # 필요 없으면 공백
       jedis:


### PR DESCRIPTION
## ✅ 연관된 이슈
> ex) #이슈번호, #이슈번호
#91 


## 📝 작업 내용
> 이번 PR에서 작업한 내용 간략히 설명
ec2 Ubuntu 환경에서 redis 주소 인식을 못하여 주소를 명심함으로 변경



