### PR TITLE
FIX: Redis host, port 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
 
   data:
     redis:
-      host: 127.0.0.1
-      port: 6379
+      host: ${REDIS_HOST:127.0.0.1}
+      port: ${REDIS_PORT:6379}
       password: "" # 필요 없으면 공백
       jedis:
         pool:


### PR DESCRIPTION
## ✅ 연관된 이슈
> ex) #이슈번호, #이슈번호
#99 

## 📝 작업 내용
> 이번 PR에서 작업한 내용 간략히 설명
하드코딩 되어있던 Redis host, port 번호 EC2 내 도커 환경에서 적용할 수 있게 수정


