### PR TITLE
FIX: 게시글 삭제 권한 검증 기준을 인증 사용자로 변경

### DIFF
--- a/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
+++ b/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
@@ -3,14 +3,15 @@ package com.AcovueMagazine.Post.Controller;
 
 import com.AcovueMagazine.Common.Response.ApiResponse;
 import com.AcovueMagazine.Common.Response.ResponseUtil;
+import com.AcovueMagazine.Member.Util.PrincipalDetails;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
 import com.AcovueMagazine.Post.Dto.PostResDto;
 import com.AcovueMagazine.Post.Entity.PostType;
 import com.AcovueMagazine.Post.Service.PostService;
-import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Post.Service.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -82,8 +83,8 @@ public class PostController {
 
     // 매거진 삭제
     @DeleteMapping("/delete/{postId}")
-    public ApiResponse<?> deleteMagazine(@PathVariable Long postId, @RequestBody Members members) {
-        PostResDto magazine = postService.deleteMagazine(postId, members);
+    public ApiResponse<?> deleteMagazine(@PathVariable Long postId, @AuthenticationPrincipal PrincipalDetails principal) {
+        PostResDto magazine = postService.deleteMagazine(postId, principal.getMemberSeq());
 
         return ResponseUtil.successResponse("매거진 삭제를 성공적으로 수행하였습니다", magazine).getBody();
     }

--- a/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
+++ b/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
@@ -190,37 +190,29 @@ public class PostService {
         return PostResDto.fromEntity(post);
     }
 
-
+    // 게시글 삭제 기능
     @Transactional
-    public PostResDto deleteMagazine(Long postId, Members currentMembers) {
-        Post magazine = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+    public PostResDto deleteMagazine(Long postId, Long memberSeq) {
 
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. POST_ID = " + postId));
 
-        if (magazine.getMembers().getMemberSeq().equals(currentMembers.getMemberSeq()) ||
-                currentMembers.getMemberRole() == MemberRole.ADMIN) {
-            postRepository.delete(magazine);
-        } else {
-            throw new org.springframework.security.access.AccessDeniedException("삭제 권한이 없습니다.");
+        Members currentMember = membersRepository.findById(memberSeq)
+                .orElseThrow( () -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. USER_ID = " + memberSeq));
+
+        boolean isWrtter = post.getMembers().getMemberSeq().equals(currentMember.getMemberSeq());
+        boolean isAdmin = currentMember.getMemberRole() == MemberRole.ADMIN;
+
+        if(!isWrtter && !isAdmin){
+            throw new AccessDeniedException("삭제 권한이 없습니다.");
         }
 
+        postRepository.delete(post);
 
-        return PostResDto.fromEntity(magazine);
+        return PostResDto.fromEntity(post);
     }
 
-    /**
-     * Searches magazines by keyword and optional registration-date range, returning DTOs ordered by registration date.
-     *
-     * The search matches the keyword against title or content and filters by registration date between
-     * `start` and `end` (if provided). Results are sorted by `regDate` descending when `newestFirst` is true,
-     * otherwise ascending.
-     *
-     * @param keyword     text to match against magazine title or content; null or empty matches all
-     * @param start       start of the registration-date range (inclusive); may be null to omit lower bound
-     * @param end         end of the registration-date range (inclusive); may be null to omit upper bound
-     * @param newestFirst if true, sort results by `regDate` descending; if false, sort ascending
-     * @return a list of MagazineResDTOs representing matched magazines (may be empty)
-     */
+
     public List<PostResDto> searchPost(String keyword, LocalDateTime start, LocalDateTime end, boolean newestFirst) {
         Specification<Post> spec = Specification
                 .where(PostSpecification.titleOrContentContains(keyword))


### PR DESCRIPTION
## ✅ 연관된 이슈
#104 


## 📝 작업 내용
> 게시글 삭제 API의 권한 검증 기준을 요청 바디의 사용자 정보에서 인증된 사용자 정보로 변경

- 기존에는 클라이언트가 전달한 `Members` 객체를 기반으로 삭제 권한을 판단하고 있어, 요청 바디 조작 시 권한 검증 기준이 불명확한 상황

- 이제는 `@AuthenticationPrincipal`을 통해 인증된 사용자의 `memberSeq`를 전달하고, 서비스 계층에서 DB 조회 후 작성자 또는 관리자 여부를 검증하는 방식으로 변경됨

## Changes

- 게시글 삭제 API에서 `@RequestBody Members` 제거
- `@AuthenticationPrincipal PrincipalDetails` 기반으로 현재 로그인 사용자 식별
- `PostService.deleteMagazine()`이 `Long memberSeq`를 받아 현재 사용자를 DB에서 조회하도록 변경
- 게시글 작성자 또는 `ADMIN`만 삭제 가능하도록 인가 로직 정리

## Why

권한 검증은 클라이언트가 전달한 값이 아니라 서버가 검증한 인증 정보와 DB 상태를 기준으로 수행해야 합니다.  
이번 변경으로 게시글 삭제 API가 클라이언트 입력에 의존하지 않고, 서버가 신뢰할 수 있는 인증 주체 기반으로 동작하도록 개선했습니다.


## Notes

이번 PR은 게시글 삭제 권한 검증 기준 개선에 집중합니다.  
소프트 삭제(`ACTIVE -> INACTIVE`)와 삭제 게시글 조회 제외 처리는 별도 이슈에서 진행할 예정입니다.