### PR TITLE
FIX: Redis 값 지정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     command: ["redis-server", "--appendonly", "yes"] # 데이터 지속화 옵션
     volumes:
       - redis-data:/data           # 데이터 저장용 볼륨
+  app:
+    environment:
+      - REDIS_HOST:redis-dev
 
 volumes:
   redis-data:


### PR DESCRIPTION
## ✅ 연관된 이슈
> #108


## 📝 작업 내용
> Redis가 internal로 설정되어있어서 docker 환경에서 Redis를 못찾는 상황 발생
-> 이로 인해 OAuth 로그인 시 Redis DB를 찾지 못하여 로그인이 안되는 상황 발생
-> 서버에서 찾고있는 이름으로 Redis DB 이름을 변경



