### PR TITLE
fix: About Me 수정 권한 체크 기준 수정

### DIFF
--- a/src/main/java/com/AcovueMagazine/AboutMe/Service/AboutMeService.java
+++ b/src/main/java/com/AcovueMagazine/AboutMe/Service/AboutMeService.java
@@ -44,9 +44,6 @@ public class AboutMeService {
             throw new NullPointerException("해당 MemberSeq가 조회되지 않습니다.");
         }
 
-        if (memberSeq != 1){
-            throw new AccessDeniedException("해당 기능에 접근 가능한 계정이 아닙니다.");
-        }
 
         AboutMe aboutMe = aboutMeRepository.findByaboutMeSeq(1);
 

--- a/src/main/java/com/AcovueMagazine/Member/Util/MemberDetail.java
+++ b/src/main/java/com/AcovueMagazine/Member/Util/MemberDetail.java
@@ -2,7 +2,6 @@ package com.AcovueMagazine.Member.Util;
 
 import com.AcovueMagazine.Member.Entity.Members;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;


### PR DESCRIPTION
• ## ✅ 연관된 이슈
 Closes #103 

  ## 📝 작업 내용
  > About Me 수정 시 관리자 계정이어도 특정 `memberSeq`가 아니면 403 발생하던 문제 수정함

  - `SecurityConfig`에서는 `ADMIN` 권한을 허용하고 있었으나, 서비스 계층에서 `memberSeq == 1` 여부를 추가로 검사하고 있
  었음
  - 이로 인해 `ADMIN` 권한을 가진 다른 관리자 계정은 About Me 수정이 불가능했음
  - 하드코딩된 `memberSeq` 체크 제거하고, 관리자 권한 기준으로 수정 가능하도록 정리함

  ## 🔍 확인 사항
  - 관리자 JWT에 `auth: ADMIN` 포함된 상태 확인함
  - `PUT /api/aboutMe/update` 요청 시 403 발생 원인 확인함
  - About Me 수정 권한 기준이 특정 회원 ID에 의존하지 않도록 수정함