### PR TITLE
refact: about_me_content 타입 변경

### DIFF
--- a/src/main/java/com/AcovueMagazine/AboutMe/Entity/AboutMe.java
+++ b/src/main/java/com/AcovueMagazine/AboutMe/Entity/AboutMe.java
@@ -22,7 +22,7 @@ public class AboutMe {
     private Members members;
 
     @Lob // Text 타입 지정
-    @Column(name = "about_me_content", nullable = false)
+    @Column(name = "about_me_content", columnDefinition = "LONGTEXT", nullable = false)
     private String aboutMeContent;
 
 


### PR DESCRIPTION
 ## ✅ 연관된 이슈
  > close: #119

  ## 📝 작업 내용
  > About Me 본문에 더 긴 리치 텍스트 콘텐츠를 저장할 수 있도록 수정함

  - `about_me_content` 컬럼 매핑을 `LONGTEXT`로 변경함
  - 긴 About Me 본문 저장을 위해 `@Lob` 적용함