### PR TITLE
refact: Post 리팩토링 Community 하위 Enum 추가

### DIFF
--- a/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
+++ b/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
@@ -6,6 +6,7 @@ import com.AcovueMagazine.Common.Response.ResponseUtil;
 import com.AcovueMagazine.Member.Util.PrincipalDetails;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
 import com.AcovueMagazine.Post.Dto.PostResDto;
+import com.AcovueMagazine.Post.Entity.CommunityCategory;
 import com.AcovueMagazine.Post.Entity.PostType;
 import com.AcovueMagazine.Post.Service.PostService;
 import com.AcovueMagazine.Post.Service.S3UploadService;
@@ -48,43 +49,49 @@ public class PostController {
      */
     @GetMapping("/find/all")
     public ApiResponse<?> getPostList(
-            @RequestParam(required = false, defaultValue = "10") Integer limit, // 페이지당 개수 (기본값은 10)
-            @RequestParam(required = false, defaultValue = "1") Integer page, // 페이지 번호 (기본값은 1)
-            @RequestParam(required = false) String type // 게시물 타입
+            @RequestParam(required = false, defaultValue = "10") Integer limit,
+            @RequestParam(required = false, defaultValue = "1") Integer page,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String communityCategory
     ) {
-        // Category -> Enum
+
         PostType postType = (type != null) ? PostType.valueOf(type.toUpperCase()) : null;
 
-        List<PostResDto> posts = postService.getAllPosts(limit, page, postType);
+        CommunityCategory communityCategoryEnum=
+                (communityCategory != null)
+                        ? CommunityCategory.valueOf(communityCategory.toUpperCase())
+                        : null;
+
+        List<PostResDto> posts = postService.getAllPosts(limit, page, postType, communityCategoryEnum);
 
         return ResponseUtil.successResponse("매거진 전체 조회를 성공적으로 수행하였습니다.", posts).getBody();
     }
 
     // 매거진 상세조회
-    @GetMapping("/find/{magazineId}")
-    public ApiResponse<?> getMagazineById(@PathVariable Long magazineId) {
-        PostResDto magazine = postService.getMagazine(magazineId);
+    @GetMapping("/find/{postSeq}")
+    public ApiResponse<?> getPostBySeq(@PathVariable Long postSeq) {
+        PostResDto magazine = postService.getPost(postSeq);
         return ResponseUtil.successResponse("매거진 상세조회를 성공적으로 수행하였습니다.", magazine).getBody();
     }
 
     // 매거진 등록
     @PostMapping("/create")
-    public ApiResponse<?> createMagazine(@RequestBody PostReqDto magazineReqDTO) {
-        PostResDto magazine = postService.createMagazine(magazineReqDTO);
+    public ApiResponse<?> createPost(@RequestBody PostReqDto postReqDTO) {
+        PostResDto magazine = postService.createPost(postReqDTO);
         return ResponseUtil.successResponse("매거진 생성을 성공적으로 수행하였습니다.", magazine).getBody();
     }
 
     // 매거진 수정
-    @PutMapping("/update/{postId}")
-    public ApiResponse<?> updateMagazine(@PathVariable Long postId, @RequestBody PostReqDto PostReqDTO) {
-        PostResDto magazine = postService.updateMagazine(PostReqDTO, postId);
+    @PutMapping("/update/{postSeq}")
+    public ApiResponse<?> updatePost(@PathVariable Long postSeq, @RequestBody PostReqDto PostReqDTO) {
+        PostResDto magazine = postService.updatePost(PostReqDTO, postSeq);
         return ResponseUtil.successResponse("매거진 수정이 성공적으로 수행되었습니다.", magazine).getBody();
     }
 
     // 매거진 삭제
-    @DeleteMapping("/delete/{postId}")
-    public ApiResponse<?> deleteMagazine(@PathVariable Long postId, @AuthenticationPrincipal PrincipalDetails principal) {
-        PostResDto magazine = postService.deleteMagazine(postId, principal.getMemberSeq());
+    @DeleteMapping("/delete/{postSeq}")
+    public ApiResponse<?> deletePost(@PathVariable Long postSeq, @AuthenticationPrincipal PrincipalDetails principal) {
+        PostResDto magazine = postService.deletePost(postSeq, principal.getMemberSeq());
 
         return ResponseUtil.successResponse("매거진 삭제를 성공적으로 수행하였습니다", magazine).getBody();
     }

--- a/src/main/java/com/AcovueMagazine/Post/Dto/PostReqDto.java
+++ b/src/main/java/com/AcovueMagazine/Post/Dto/PostReqDto.java
@@ -1,5 +1,6 @@
 package com.AcovueMagazine.Post.Dto;
 
+import com.AcovueMagazine.Post.Entity.CommunityCategory;
 import com.AcovueMagazine.Post.Entity.PostType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,4 +20,6 @@ public class PostReqDto {
     private PostType post_category;
     private List<String> imageUrls;
     private String thumbnail_url;
+    private CommunityCategory communityCategory;
+    private Boolean notice;
 }

--- a/src/main/java/com/AcovueMagazine/Post/Dto/PostResDto.java
+++ b/src/main/java/com/AcovueMagazine/Post/Dto/PostResDto.java
@@ -1,5 +1,6 @@
 package com.AcovueMagazine.Post.Dto;
 
+import com.AcovueMagazine.Post.Entity.CommunityCategory;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Member.Entity.MemberStatus;
 import com.AcovueMagazine.Post.Entity.PostImage;
@@ -32,6 +33,8 @@ public class PostResDto {
     private LocalDateTime modDate;
     private List<String> imageUrls;
     private String thumbnailUrl;
+    private CommunityCategory communityCategory;
+    private Boolean notice;
 
 
     // Entity -> DTO
@@ -54,7 +57,9 @@ public class PostResDto {
                 magazine.getRegDate(),
                 magazine.getModDate(),
                 urls,
-                magazine.getThumbnailUrl()
+                magazine.getThumbnailUrl(),
+                magazine.getCommunityCategory(),
+                magazine.getNotice()
         );
     }
 }

--- a/src/main/java/com/AcovueMagazine/Post/Entity/CommunityCategory.java
+++ b/src/main/java/com/AcovueMagazine/Post/Entity/CommunityCategory.java
@@ -1,0 +1,7 @@
+package com.AcovueMagazine.Post.Entity;
+
+public enum CommunityCategory {
+    REVIEW,
+    COMPANION,
+    QNA
+}

--- a/src/main/java/com/AcovueMagazine/Post/Entity/Post.java
+++ b/src/main/java/com/AcovueMagazine/Post/Entity/Post.java
@@ -58,13 +58,22 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> images = new ArrayList<>();
 
-    public Post(Members members, String postTitle, String postContent, PostType postCategory, String thumbnailUrl) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "community_category")
+    private CommunityCategory communityCategory;
+
+    @Column(name="is_notice", nullable = false)
+    private Boolean notice = false;
+
+    public Post(Members members, String postTitle, String postContent, PostType postCategory, String thumbnailUrl, CommunityCategory communityCategory, Boolean notice) {
         this.members = members;
         this.postTitle = postTitle;
         this.postContent = postContent;
         this.postStatus = PostStatus.ACTIVE;
         this.postCategory = postCategory;
         this.thumbnailUrl = thumbnailUrl;
+        this.communityCategory = communityCategory;
+        this.notice = notice;
     }
 
     public void addImage(PostImage postImage){
@@ -81,6 +90,14 @@ public class Post {
 
     public void updateThumbnailUrl(String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void updateNotice(Boolean notice) {
+        this.notice = notice;
+    }
+
+    public void updateCommunityCategory(CommunityCategory communityCategory) {
+        this.communityCategory = communityCategory;
     }
 
     public void inActivate() {

--- a/src/main/java/com/AcovueMagazine/Post/Repository/PostRepository.java
+++ b/src/main/java/com/AcovueMagazine/Post/Repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.AcovueMagazine.Post.Repository;
 
+import com.AcovueMagazine.Post.Entity.CommunityCategory;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Post.Entity.PostStatus;
 import com.AcovueMagazine.Post.Entity.PostType;
@@ -29,4 +30,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByPostCategoryAndPostStatus(PostType postType, PostStatus postStatus, Pageable pageable);
 
     Page<Post> findByPostStatus(PostStatus postStatus, Pageable pageable);
+
+    Page<Post> findByPostCategoryAndCommunityCategoryAndPostStatus(PostType postType, CommunityCategory communityCategory, PostStatus postStatus, Pageable pageable);
 }

--- a/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
+++ b/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
@@ -2,11 +2,8 @@ package com.AcovueMagazine.Post.Service;
 
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
-import com.AcovueMagazine.Post.Entity.Post;
+import com.AcovueMagazine.Post.Entity.*;
 import com.AcovueMagazine.Post.Dto.PostResDto;
-import com.AcovueMagazine.Post.Entity.PostImage;
-import com.AcovueMagazine.Post.Entity.PostStatus;
-import com.AcovueMagazine.Post.Entity.PostType;
 import com.AcovueMagazine.Post.Repository.PostRepository;
 import com.AcovueMagazine.Member.Entity.MemberRole;
 import com.AcovueMagazine.Member.Entity.Members;
@@ -38,53 +35,48 @@ public class PostService {
     private final MembersRepository membersRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // Post 조회 ( Limit, page, PostType )
     @Transactional
-    public List<PostResDto> getAllPosts(Integer limit, Integer page, PostType postType) {
+    public List<PostResDto> getAllPosts(Integer limit, Integer page, PostType postType, CommunityCategory communityCategory) {
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "regDate");
+        Sort sort = postType == PostType.COMMUNITY
+                ? Sort.by(Sort.Order.desc("notice"), Sort.Order.desc("regDate"))
+                : Sort.by(Sort.Direction.DESC, "regDate");
+
         Pageable pageable = PageRequest.of(page - 1, limit, sort);
 
         Page<Post> postPage;
 
-        if(postType != null){
-            // 특정 카테고리 지정 된 케이스
-            postPage = postRepository.findByPostCategoryAndPostStatus(postType, PostStatus.ACTIVE, pageable);
+        if (postType == PostType.COMMUNITY && communityCategory != null) {
+            postPage = postRepository.findByPostCategoryAndCommunityCategoryAndPostStatus(
+                    PostType.COMMUNITY,
+                    communityCategory,
+                    PostStatus.ACTIVE,
+                    pageable
+            );
+        } else if (postType != null) {
+            postPage = postRepository.findByPostCategoryAndPostStatus(
+                    postType,
+                    PostStatus.ACTIVE,
+                    pageable
+            );
         } else {
-            // 카테고리 지정 안된 케이스
-            postPage = postRepository.findByPostStatus(PostStatus.ACTIVE, pageable);
+            postPage = postRepository.findByPostStatus(
+                    PostStatus.ACTIVE,
+                    pageable
+            );
         }
 
+
         return postPage.getContent().stream()
-                .map(post ->  {
-
-                    List<String> urls = post.getImages().stream()
-                            .map(PostImage::getImageUrl)
-                            .collect(Collectors.toList());
-
-                    return new PostResDto(
-                            post.getMembers().getMemberSeq(),
-                            post.getMembers().getMemberName(),
-                            post.getMembers().getMemberNickname(),
-                            post.getMembers().getMemberEmail(),
-                            post.getMembers().getMemberStatus(),
-                            post.getPostSeq(),
-                            post.getPostTitle(),
-                            post.getPostContent(),
-                            post.getPostCategory(),
-                            post.getRegDate(),
-                            post.getModDate(),
-                            urls,
-                            post.getThumbnailUrl()
-                    );
-                }).collect(Collectors.toList());
+                .map(PostResDto::fromEntity)
+                .collect(Collectors.toList());
     }
 
     // 매거진 상세 조회
     @Transactional
-    public PostResDto getMagazine(Long postId) {
-        Post post = postRepository.findByPostSeqAndPostStatus(postId, PostStatus.ACTIVE)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+    public PostResDto getPost(Long postSeq) {
+        Post post = postRepository.findByPostSeqAndPostStatus(postSeq, PostStatus.ACTIVE)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postSeq));
 
         if (post.getMembers().getMemberStatus() == MemberStatus.INACTIVE) {
             throw new IllegalStateException("비활성화된 유저입니다.");
@@ -95,7 +87,7 @@ public class PostService {
 
     // 매거진 생성 기능
     @Transactional
-    public PostResDto createMagazine(PostReqDto postReqDTO) {
+    public PostResDto createPost(PostReqDto postReqDTO) {
 
         String accessToken = jwtTokenProvider.resolveToken();
 
@@ -115,9 +107,21 @@ public class PostService {
         Members members = membersRepository.findById(memberSeq)
                 .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
 
-        System.out.println("넘어온 이미지 리스트: " + postReqDTO.getImageUrls());
+        boolean requestedNotice = Boolean.TRUE.equals(postReqDTO.getNotice());
 
-        Post post = new Post(members, postReqDTO.getPost_title(), postReqDTO.getPost_content(), postReqDTO.getPost_category(), postReqDTO.getThumbnail_url());
+        if(requestedNotice && members.getMemberRole() != MemberRole.ADMIN){
+            throw new AccessDeniedException("공지 작성 권한이 없습니다.");
+        }
+
+        Post post = new Post(
+                members,
+                postReqDTO.getPost_title(),
+                postReqDTO.getPost_content(),
+                postReqDTO.getPost_category(),
+                postReqDTO.getThumbnail_url(),
+                postReqDTO.getCommunityCategory(),
+                requestedNotice
+        );
 
         if(postReqDTO.getImageUrls() != null && !postReqDTO.getImageUrls().isEmpty()){
             for(String url : postReqDTO.getImageUrls()){
@@ -137,7 +141,7 @@ public class PostService {
 
     // 매거진 수정 기능
     @Transactional
-    public PostResDto updateMagazine(PostReqDto postReqDTO, Long postId) {
+    public PostResDto updatePost(PostReqDto postReqDTO, Long postSeq) {
 
         String accessToken = jwtTokenProvider.resolveToken();
 
@@ -154,23 +158,21 @@ public class PostService {
             throw new NullPointerException("해당 MemberSeq가 조회되지 않습니다.");
         }
 
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+        Post post = postRepository.findById(postSeq)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postSeq));
 
         Members members = membersRepository.findById(memberSeq)
                 .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
 
-        // 권한 체크
-        // 1. 작성자인지 확인 (게시글 작성자 ID == 현재 로그인한 유저 ID)
         boolean isWriter = post.getMembers().getMemberSeq().equals(members.getMemberSeq());
-
-        // 2. 관리자인지 확인 (현재 로그인한 유저의 Role이 ADMIN인지)
-        // 주의: post.getMembers()가 아니라 현재 로그인한 'members'의 권한을 확인해야 합니다.
         boolean isAdmin = (members.getMemberRole() == MemberRole.ADMIN);
 
-        // 3. 검증: 작성자도 아니고(AND) 관리자도 아니면 -> 권한 없음 예외 발생
         if (!isWriter && !isAdmin) {
             throw new AccessDeniedException("수정 권한이 없습니다.");
+        }
+
+        if (postReqDTO.getNotice() != null && !isAdmin){
+            throw new AccessDeniedException("공지 수정 권한이 없습니다.");
         }
 
         // 제목 수정이 있으면 저장
@@ -188,15 +190,23 @@ public class PostService {
             post.updateThumbnailUrl(postReqDTO.getThumbnail_url());
         }
 
+        if (postReqDTO.getCommunityCategory() != null) {
+            post.updateCommunityCategory(postReqDTO.getCommunityCategory());
+        }
+
+        if (postReqDTO.getNotice() != null) {
+            post.updateNotice(postReqDTO.getNotice());
+        }
+
         return PostResDto.fromEntity(post);
     }
 
     // 게시글 삭제 기능
     @Transactional
-    public PostResDto deleteMagazine(Long postId, Long memberSeq) {
+    public PostResDto deletePost(Long postSeq, Long memberSeq) {
 
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. POST_ID = " + postId));
+        Post post = postRepository.findById(postSeq)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. POST_ID = " + postSeq));
 
         Members currentMember = membersRepository.findById(memberSeq)
                 .orElseThrow( () -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. USER_ID = " + memberSeq));
@@ -227,27 +237,7 @@ public class PostService {
 
 
         return searchMagazines.stream()
-                .map(magazine -> {
-                    List<String> extractedUrls = magazine.getImages().stream()
-                            .map(PostImage::getImageUrl) // (또는 PostImage::getImageUrl)
-                            .collect(Collectors.toList());
-
-                    return new PostResDto(
-                            magazine.getMembers().getMemberSeq(),
-                            magazine.getMembers().getMemberName(),
-                            magazine.getMembers().getMemberNickname(),
-                            magazine.getMembers().getMemberEmail(),
-                            magazine.getMembers().getMemberStatus(),
-                            magazine.getPostSeq(),
-                            magazine.getPostTitle(),
-                            magazine.getPostContent(),
-                            magazine.getPostCategory(),
-                            magazine.getRegDate(),
-                            magazine.getModDate(),
-                            extractedUrls,
-                            magazine.getThumbnailUrl()
-                    );
-                })
+                .map(PostResDto::fromEntity)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
• ## ✅ 연관된 이슈
  > ex) #121 


  ## 📝 작업 내용
  - 커뮤니티 게시글 세부 카테고리 기능을 추가했습니다.
    - 공연 후기: `REVIEW`
    - 동행/양도: `COMPANION`
    - Q&A: `QNA`
  - 커뮤니티 게시글 공지 여부를 저장할 수 있도록 `notice` 필드를 추가했습니다.
  - 커뮤니티 목록 조회 시 공지 게시글이 상단에 노출되도록 정렬을 적용했습니다.
  - 커뮤니티 세부 카테고리별 목록 조회를 지원하도록 API 조회 조건을 확장했습니다.
  - 공지 작성 및 수정은 관리자만 가능하도록 권한 검증을 추가했습니다.
  - 게시글 응답 DTO에 `communityCategory`, `notice` 필드를 포함하도록 수정했습니다.
  - 변경된 게시글 서비스 메서드명과 엔티티 생성자에 맞춰 테스트 코드를 수정했습니다.