### PR TITLE
refact: Post 리팩토링 전체 조회 시 like, comment count 추가해서 조회 할 수 있도록 수정

### DIFF
--- a/src/main/java/com/AcovueMagazine/Post/Dto/PostResDto.java
+++ b/src/main/java/com/AcovueMagazine/Post/Dto/PostResDto.java
@@ -35,10 +35,20 @@ public class PostResDto {
     private String thumbnailUrl;
     private CommunityCategory communityCategory;
     private Boolean notice;
+    private Long commentCount;
+    private Long postLikeCount;
 
 
     // Entity -> DTO
     public static PostResDto fromEntity(Post magazine) {
+        return fromEntity(magazine, 0L, 0L);
+    }
+
+    public static PostResDto fromEntity(Post magazine, Long commentCount) {
+        return fromEntity(magazine, commentCount, 0L);
+    }
+
+    public static PostResDto fromEntity(Post magazine, Long commentCount, Long postLikeCount) {
 
         List<String> urls = magazine.getImages().stream()
                 .map(PostImage::getImageUrl)
@@ -59,7 +69,9 @@ public class PostResDto {
                 urls,
                 magazine.getThumbnailUrl(),
                 magazine.getCommunityCategory(),
-                magazine.getNotice()
+                magazine.getNotice(),
+                commentCount,
+                postLikeCount
         );
     }
 }

--- a/src/test/java/com/AcovueMagazine/Post/Service/PostServiceTest.java
+++ b/src/test/java/com/AcovueMagazine/Post/Service/PostServiceTest.java
@@ -1,10 +1,15 @@
 package com.AcovueMagazine.Post.Service;
 
+import com.AcovueMagazine.Comment.Entity.CommentStatus;
+import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Like.Respository.PostLikeRepository;
 import com.AcovueMagazine.Member.Entity.MemberLoginStatus;
 import com.AcovueMagazine.Member.Entity.MemberRole;
 import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Member.Repository.MembersRepository;
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
+import com.AcovueMagazine.Post.Dto.PostResDto;
+import com.AcovueMagazine.Post.Entity.CommunityCategory;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Post.Entity.PostStatus;
 import com.AcovueMagazine.Post.Entity.PostType;
@@ -14,9 +19,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.springframework.security.access.AccessDeniedException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,6 +44,12 @@ class PostServiceTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
 
     @Test
     void 게시글_작성자는_삭제_요청_시_게시글이_INACTIVE_상태가_된다(){
@@ -57,8 +71,10 @@ class PostServiceTest {
                 writer,
                 "테스트 제목",
                 "테스트 내용",
-                PostType.NEWS,
-                "thumb.jpg"
+                PostType.CONCERT_NEWS,
+                "thumb.jpg",
+                null,
+                false
         );
 
         Long postId = 1L;
@@ -68,7 +84,7 @@ class PostServiceTest {
         when(membersRepository.findById(memberSeq)).thenReturn(Optional.of(writer));
 
         //when
-        postService.deleteMagazine(postId, memberSeq);
+        postService.deletePost(postId, memberSeq);
 
         //then
         assertEquals(PostStatus.INACTIVE, post.getPostStatus());
@@ -105,15 +121,17 @@ class PostServiceTest {
                 writer,
                 "테스트 제목",
                 "테스트 내용",
-                PostType.NEWS,
-                "thumb.jpg"
+                PostType.CONCERT_NEWS,
+                "thumb.jpg",
+                null,
+                false
         );
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(post));
         when(membersRepository.findById(2L)).thenReturn(Optional.of(otherUser));
 
         //when & then
-        assertThrows(AccessDeniedException.class, () -> postService.deleteMagazine(1L, 2L));
+        assertThrows(AccessDeniedException.class, () -> postService.deletePost(1L, 2L));
         assertEquals(PostStatus.ACTIVE, post.getPostStatus());
     }
 
@@ -148,18 +166,63 @@ class PostServiceTest {
                 writer,
                 "테스트 제목",
                 "테스트 내용",
-                PostType.NEWS,
-                "thumb.jpg"
+                PostType.CONCERT_NEWS,
+                "thumb.jpg",
+                null,
+                false
         );
 
         when(postRepository.findById(1L)).thenReturn(Optional.of(post));
         when(membersRepository.findById(99L)).thenReturn(Optional.of(admin));
 
         // when
-        postService.deleteMagazine(1L, 99L);
+        postService.deletePost(1L, 99L);
 
         // then
         assertEquals(PostStatus.INACTIVE, post.getPostStatus());
+    }
+
+    @Test
+    void 게시글_목록_조회_시_댓글수와_좋아요수가_포함된다() {
+        Members writer = Members.builder()
+                .memberName("작성자")
+                .memberNickname("writer")
+                .memberEmail("writer@test.com")
+                .memberPassword("encoded")
+                .memberRole(MemberRole.USER)
+                .memberLoginStatus(MemberLoginStatus.LOGOUT)
+                .provider(null)
+                .providerId(null)
+                .build();
+        ReflectionTestUtils.setField(writer, "memberSeq", 1L);
+
+        Post post = new Post(
+                writer,
+                "테스트 제목",
+                "테스트 내용",
+                PostType.COMMUNITY,
+                "thumb.jpg",
+                CommunityCategory.REVIEW,
+                false
+        );
+        ReflectionTestUtils.setField(post, "postSeq", 10L);
+
+        when(postRepository.findByPostCategoryAndCommunityCategoryAndPostStatus(
+                org.mockito.ArgumentMatchers.eq(PostType.COMMUNITY),
+                org.mockito.ArgumentMatchers.eq(CommunityCategory.REVIEW),
+                org.mockito.ArgumentMatchers.eq(PostStatus.ACTIVE),
+                org.mockito.ArgumentMatchers.any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(post)));
+        when(commentRepository.countCommentsByPostSeqs(List.of(10L), CommentStatus.ACTIVE))
+                .thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
+        when(postLikeRepository.countPostLikesByPostSeqs(List.of(10L)))
+                .thenReturn(List.<Object[]>of(new Object[]{10L, 2L}));
+
+        List<PostResDto> posts = postService.getAllPosts(20, 1, PostType.COMMUNITY, CommunityCategory.REVIEW);
+
+        assertEquals(1, posts.size());
+        assertEquals(3L, posts.get(0).getCommentCount());
+        assertEquals(2L, posts.get(0).getPostLikeCount());
     }
 
 


### PR DESCRIPTION
## ✅ 연관된 이슈

close #123

  ## 📝 작업 내용

  > 게시글 리스트 조회 API 응답에 댓글 개수와 좋아요 개수를 포함하도록 수정했습니다.
  > 커뮤니티 리스트에서 게시글별 commentCount, postLikeCount를 바로 사용할 수 있도록 백엔드에서 게시
  > 글 목록 기준으로 count 값을 함께 내려줍니다.

  - GET /api/post/find/all 응답에 commentCount, postLikeCount 필드 추가
  - 댓글 수와 좋아요 수를 게시글별 개별 조회하지 않고, 현재 페이지의 postSeq 목록 기준으로 group by
    집계
  - 게시글 상세 페이지에서 사용할 수 있는 댓글 개수 조회 API 추가
      - GET /api/post/comment/count/{postId}
  - 리스트 조회 시 댓글 수/좋아요 수가 DTO에 포함되는지 테스트 추가
  - 기존 게시글 삭제 권한 테스트를 현재 도메인 코드에 맞게 정리