### PR TITLE
FIX: community list 조회에서 commentCount, likeCount를 같이 조회할 수 있도록 api 수정

### DIFF
--- a/src/main/java/com/AcovueMagazine/Comment/Respository/CommentRepository.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Respository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.AcovueMagazine.Comment.Respository;
 
 import com.AcovueMagazine.Comment.Entity.Comment;
+import com.AcovueMagazine.Comment.Entity.CommentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +18,18 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     // 최초 댓글 Seq 조회
     @Query("SELECT c FROM Comment c WHERE c.parent.commentSeq = :parentSeq AND c.commentStatus = 'ACTIVE' ")
     List<Comment> findByParent(@Param("parentSeq") Long parentSeq);
+
+    Long countByPost_PostSeqAndCommentStatus(Long postSeq, CommentStatus commentStatus);
+
+    @Query("""
+            SELECT c.post.postSeq, COUNT(c)
+            FROM Comment c
+            WHERE c.post.postSeq IN :postSeqs
+              AND c.commentStatus = :commentStatus
+            GROUP BY c.post.postSeq
+            """)
+    List<Object[]> countCommentsByPostSeqs(
+            @Param("postSeqs") List<Long> postSeqs,
+            @Param("commentStatus") CommentStatus commentStatus
+    );
 }

--- a/src/main/java/com/AcovueMagazine/Like/Respository/PostLikeRepository.java
+++ b/src/main/java/com/AcovueMagazine/Like/Respository/PostLikeRepository.java
@@ -4,7 +4,10 @@ import com.AcovueMagazine.Like.Entity.PostLike;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Member.Entity.Members;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -15,4 +18,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     // 매거진seq로 매거진 좋아요 개수 조회
     Long countByPost_PostSeq(Long postSeq);
+
+    @Query("""
+            SELECT pl.post.postSeq, COUNT(pl)
+            FROM PostLike pl
+            WHERE pl.post.postSeq IN :postSeqs
+            GROUP BY pl.post.postSeq
+            """)
+    List<Object[]> countPostLikesByPostSeqs(@Param("postSeqs") List<Long> postSeqs);
 }

--- a/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
+++ b/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
@@ -1,5 +1,8 @@
 package com.AcovueMagazine.Post.Service;
 
+import com.AcovueMagazine.Comment.Entity.CommentStatus;
+import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Like.Respository.PostLikeRepository;
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
 import com.AcovueMagazine.Post.Entity.*;
@@ -24,6 +27,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -34,6 +38,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final MembersRepository membersRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public List<PostResDto> getAllPosts(Integer limit, Integer page, PostType postType, CommunityCategory communityCategory) {
@@ -66,10 +72,50 @@ public class PostService {
             );
         }
 
+        List<Post> posts = postPage.getContent();
 
-        return postPage.getContent().stream()
-                .map(PostResDto::fromEntity)
-                .collect(Collectors.toList());
+        Map<Long, Long> commentCountMap = getCommentCountMap(posts);
+        Map<Long, Long> postLikeCountMap = getPostLikeCountMap(posts);
+
+        return posts.stream()
+                .map(post -> PostResDto.fromEntity(
+                        post,
+                        commentCountMap.getOrDefault(post.getPostSeq(), 0L),
+                        postLikeCountMap.getOrDefault(post.getPostSeq(), 0L)
+                ))
+                .toList();
+    }
+
+    private Map<Long, Long> getCommentCountMap(List<Post> posts) {
+        List<Long> postSeqs = posts.stream()
+                .map(Post::getPostSeq)
+                .toList();
+
+        if (postSeqs.isEmpty()) {
+            return Map.of();
+        }
+
+        return commentRepository.countCommentsByPostSeqs(postSeqs, CommentStatus.ACTIVE).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+    }
+
+    private Map<Long, Long> getPostLikeCountMap(List<Post> posts) {
+        List<Long> postSeqs = posts.stream()
+                .map(Post::getPostSeq)
+                .toList();
+
+        if (postSeqs.isEmpty()) {
+            return Map.of();
+        }
+
+        return postLikeRepository.countPostLikesByPostSeqs(postSeqs).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
     }
 
     // 매거진 상세 조회


### PR DESCRIPTION
• ## ✅ 연관된 이슈

  > close #124

  ## 📝 작업 내용

  > 커뮤니티 리스트와 게시글 상세에서 댓글 개수 및 좋아요 개수를 조회해 사용할 수 있도록 백엔드 응답과
  > 프론트 표시 로직을 수정했습니다.

  - 게시글 리스트 조회 API(GET /api/post/find/all) 응답에 commentCount, postLikeCount 추가
  - 댓글 수는 Comment 테이블의 post_seq 기준으로 집계
  - 좋아요 수는 post_like 테이블의 post_seq 기준으로 집계
  - 게시글 목록 조회 시 게시글별 개별 count API 호출 없이 postSeq 목록 기준으로 한 번에 조회하도록 처
    리
  - 게시글 상세용 댓글 개수 조회 API 추가
      - GET /api/post/comment/count/{postId}
  - 커뮤니티 리스트/하위 카테고리 리스트에서 댓글 수와 좋아요 수 표시
  - 게시글 상세 페이지에서 댓글 개수 API 값을 사용하도록 연결
  - count API 실패 시 기존 댓글 목록 기반으로 개수를 계산하는 fallback 처리 추가
  - 관련 테스트 및 빌드 확인