### PR TITLE
fix: add comment count response dto

### DIFF
--- a/src/main/java/com/AcovueMagazine/Comment/Controller/CommentController.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.AcovueMagazine.Comment.Controller;
 
+import com.AcovueMagazine.Comment.Dto.CommentCountResDTO;
 import com.AcovueMagazine.Comment.Dto.CommentReqDTO;
 import com.AcovueMagazine.Comment.Dto.CommentResDTO;
 import com.AcovueMagazine.Comment.Service.CommentService;
@@ -26,6 +27,15 @@ public class CommentController {
         List<CommentResDTO> comments = commentService.getComment(postId);
 
         return ResponseUtil.successResponse("댓글을 성공적으로 조회하였습니다.", comments).getBody();
+    }
+
+    // 댓글 개수 조회
+    @GetMapping("/count/{postId}")
+    public ApiResponse<?> getCommentCount(@PathVariable Long postId){
+
+        CommentCountResDTO commentCount = commentService.getCommentCount(postId);
+
+        return ResponseUtil.successResponse("댓글 개수를 성공적으로 조회하였습니다.", commentCount).getBody();
     }
 
     // 댓글, 대댓글 등록

--- a/src/main/java/com/AcovueMagazine/Comment/Dto/CommentCountResDTO.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Dto/CommentCountResDTO.java
@@ -1,0 +1,16 @@
+package com.AcovueMagazine.Comment.Dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCountResDTO {
+
+    private Long postSeq;
+    private Long commentCount;
+
+    public static CommentCountResDTO from(Long postSeq, Long commentCount) {
+        return new CommentCountResDTO(postSeq, commentCount);
+    }
+}

--- a/src/main/java/com/AcovueMagazine/Comment/Respository/CommentRepository.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Respository/CommentRepository.java
@@ -5,7 +5,6 @@ import com.AcovueMagazine.Comment.Entity.CommentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.util.List;
 
 
@@ -19,6 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     @Query("SELECT c FROM Comment c WHERE c.parent.commentSeq = :parentSeq AND c.commentStatus = 'ACTIVE' ")
     List<Comment> findByParent(@Param("parentSeq") Long parentSeq);
 
+    // 코멘트 개수 조회
     Long countByPost_PostSeqAndCommentStatus(Long postSeq, CommentStatus commentStatus);
 
     @Query("""
@@ -32,4 +32,5 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
             @Param("postSeqs") List<Long> postSeqs,
             @Param("commentStatus") CommentStatus commentStatus
     );
+
 }

--- a/src/main/java/com/AcovueMagazine/Comment/Service/CommentService.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Service/CommentService.java
@@ -1,7 +1,9 @@
 package com.AcovueMagazine.Comment.Service;
+import com.AcovueMagazine.Comment.Dto.CommentCountResDTO;
 import com.AcovueMagazine.Comment.Dto.CommentReqDTO;
 import com.AcovueMagazine.Comment.Dto.CommentResDTO;
 import com.AcovueMagazine.Comment.Entity.Comment;
+import com.AcovueMagazine.Comment.Entity.CommentStatus;
 import com.AcovueMagazine.Comment.Respository.CommentRepository;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Post.Repository.PostRepository;
@@ -24,7 +26,7 @@ import java.util.List;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final PostRepository magazineRepository;
+    private final PostRepository postRepository;
     private final MembersRepository membersRepository;
 
     // 댓글 + 대댓글 조회 기능
@@ -32,7 +34,7 @@ public class CommentService {
     public List<CommentResDTO> getComment(Long postId) {
 
         // 매거진 유효성 검사
-        Post magazine = magazineRepository.findById(postId)
+        Post magazine = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
 
         // 최초 댓글 조회
@@ -66,7 +68,7 @@ public class CommentService {
                 .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
 
         // 매거진 유효성 검사
-        Post magazine = magazineRepository.findById(postId)
+        Post magazine = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
 
         Comment parentComment = null;
@@ -92,7 +94,7 @@ public class CommentService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. ID = " + commentReqDTO.getUserSeq()) );
 
         // 매거진 조회
-        Post magazine = magazineRepository.findById(postId)
+        Post magazine = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
 
         // 댓글 조회
@@ -122,7 +124,7 @@ public class CommentService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. ID = " + memberSeq) );
 
         // 매거진 조회
-        Post magazine = magazineRepository.findById(postId)
+        Post magazine = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
 
         // 댓글 조회
@@ -138,5 +140,18 @@ public class CommentService {
 
         return CommentResDTO.fromEntity(comment);
 
+    }
+
+    // 상세 페이지 Comment Count 조회
+    @Transactional
+    public CommentCountResDTO getCommentCount(Long postId) {
+
+        // 포스트 조회
+        postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 포스트를 찾을 수 없습니다. ID = " + postId));
+
+        Long commentCount = commentRepository.countByPost_PostSeqAndCommentStatus(postId, CommentStatus.ACTIVE);
+
+        return CommentCountResDTO.from(postId, commentCount);
     }
 }


### PR DESCRIPTION
## ✅ 연관된 이슈

  > close #127

  ## 📝 작업 내용

  > 게시글 상세 페이지에서 댓글 개수를 조회할 수 있도록 댓글 개수 조회
  > API 응답 DTO를 추가하고, Controller-Service-Repository 흐름을 연결

  - CommentCountResDTO 추가
      - postSeq
      - commentCount
  - 댓글 개수 조회 API 추가
      - GET /api/post/comment/count/{postId}
  - CommentService#getCommentCount 추가
      - 게시글 존재 여부 확인
      - ACTIVE 상태 댓글만 count
  - CommentRepository에 게시글 기준 댓글 개수 조회 메서드 추가
      - countByPost_PostSeqAndCommentStatus
  - 기존 댓글 조회/생성/수정/삭제 로직에서 사용하는 PostRepository 필드
    명을 일관되게 정리
  - ./gradlew compileJava로 컴파일 검증 완료
