### PR TITLE
FIX: add access token reissue endpoint

### DIFF
--- a/src/main/java/com/AcovueMagazine/Member/Config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/AcovueMagazine/Member/Config/JwtAuthenticationFilter.java
@@ -35,7 +35,11 @@ public class JwtAuthenticationFilter extends GenericFilter {
         String path = request.getRequestURI();
 
         // 로그인/회원가입 경로는 JWT 검증 없이 통과
-        if (path.startsWith("/api/member/sign-up") || path.startsWith("/api/member/login")) {
+        if (path.startsWith("/api/member/sign-up") ||
+            path.startsWith("/api/member/sing-up") ||
+            path.startsWith("/api/member/login")   ||
+            path.startsWith("/api/member/reissue")
+        ) {
             filterChain.doFilter(servletRequest, servletResponse);
             return;
         }

--- a/src/main/java/com/AcovueMagazine/Member/Config/SecurityConfig.java
+++ b/src/main/java/com/AcovueMagazine/Member/Config/SecurityConfig.java
@@ -58,7 +58,9 @@ public class SecurityConfig {
                         // 사용자 삭제 권한은 관리자만
                         .requestMatchers(HttpMethod.DELETE, "/user").hasRole("ADMIN")
                         .requestMatchers("/members/role").hasRole("USER")
-                        .requestMatchers(HttpMethod.POST, "/api/member/*").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/member/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/member/sing-up").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/member/reissue").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/member/me/update").hasAnyAuthority("USER", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/post/**").hasAnyAuthority("USER", "ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/post/**").hasAnyAuthority("USER", "ADMIN")

--- a/src/main/java/com/AcovueMagazine/Member/Controller/MemberController.java
+++ b/src/main/java/com/AcovueMagazine/Member/Controller/MemberController.java
@@ -138,7 +138,14 @@ public class MemberController {
         return ResponseUtil.successResponse("성공적으로 회원 정보 변경이 완료되었습니다.", members).getBody();
     }
 
+    // access token 만료 후 refreshToken 발급 -> accessToken 재발급으로 이어지는 기능
+    @PostMapping("/reissue")
+    public ApiResponse<?> reissue(@RequestHeader("Refresh-Token")
+                                     String refreshTokenHeader){
+        MemberLoginDto.TokenReissueResDTO response = memberService.reissueAccessToken(refreshTokenHeader);
 
+        return ResponseUtil.successResponse("성공적으로 accessToken이 재 발급 되었습니다.", response).getBody();
+    }
 
 
 

--- a/src/main/java/com/AcovueMagazine/Member/Dto/MemberLoginDto.java
+++ b/src/main/java/com/AcovueMagazine/Member/Dto/MemberLoginDto.java
@@ -23,4 +23,11 @@ public class MemberLoginDto {
         private Long refreshTokenExpirationTime;
     }
 
+    @Getter
+    @Builder
+    public static class TokenReissueResDTO{
+        private String grantType;
+        private String accessToken;
+    }
+
 }

--- a/src/main/java/com/AcovueMagazine/Member/Service/MemberService.java
+++ b/src/main/java/com/AcovueMagazine/Member/Service/MemberService.java
@@ -212,4 +212,29 @@ public class MemberService {
 
         return MemberDataDto.from(members);
     }
+
+    //accessToken 재발급
+    public MemberLoginDto.TokenReissueResDTO reissueAccessToken(String refreshTokenHeader) {
+
+        if(refreshTokenHeader == null || !refreshTokenHeader.startsWith("Bearer ")){
+            throw new IllegalArgumentException("RefreshToken 형식이 올바르지 않습니다.");
+        }
+
+        String refreshToken = refreshTokenHeader.substring(7);
+
+        if(!jwtTokenProvider.validateRefreshToken(refreshToken)){
+            throw new IllegalArgumentException("유효하지 않은 RefreshToken 입니다.");
+        }
+
+        String email = jwtTokenProvider.getUsernameFromRefreshToken(refreshToken);
+
+        Members member = membersRepository.findByMemberEmail(email).orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtTokenProvider.reissueAccessToken(member);
+
+        return MemberLoginDto.TokenReissueResDTO.builder()
+                .grantType("Bearer")
+                .accessToken(newAccessToken)
+                .build();
+    }
 }

--- a/src/main/java/com/AcovueMagazine/Member/Util/JwtTokenProvider.java
+++ b/src/main/java/com/AcovueMagazine/Member/Util/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.AcovueMagazine.Member.Util;
 
 import com.AcovueMagazine.Member.Dao.RedisDao;
 import com.AcovueMagazine.Member.Dto.MemberLoginDto;
+import com.AcovueMagazine.Member.Entity.Members;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,13 +13,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.crypto.SecretKey;
-import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -67,6 +66,7 @@ public class JwtTokenProvider {
 
         Object principal = authentication.getPrincipal();
         if (principal instanceof MemberDetail memberDetail) {
+            username = memberDetail.getMember().getMemberEmail();
             memberSeq = memberDetail.getMember().getMemberSeq();
         } else if(principal instanceof User user){
             throw new IllegalArgumentException("MemberSeq를 가져올 수 없습니다.");
@@ -74,7 +74,7 @@ public class JwtTokenProvider {
             throw new IllegalArgumentException("알 수 없는 principal 타입");
         }
 
-        //AccessToken생성
+        //AccessToken 생성
         Date accessTokenExpire = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         String accessToken = generateAccessToken(username, authorities, memberSeq, accessTokenExpire);
 
@@ -250,6 +250,19 @@ public class JwtTokenProvider {
         return null;
     }
 
+    public String getUsernameFromRefreshToken(String refreshToken){
+        return getUserNameFromToken(refreshToken);
+    }
 
+    public String reissueAccessToken(Members member){
+        String authorities = member.getMemberRole().name();
+        Date accessTokenExpire = new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME);
 
+        return generateAccessToken(
+                member.getMemberEmail(),
+                authorities,
+                member.getMemberSeq(),
+                accessTokenExpire
+        );
+    }
 }

--- a/src/main/java/com/AcovueMagazine/Member/Util/MemberDetail.java
+++ b/src/main/java/com/AcovueMagazine/Member/Util/MemberDetail.java
@@ -48,7 +48,7 @@ public class MemberDetail implements UserDetails, OAuth2User {
 
     @Override
     public String getUsername() {
-        return this.member.getMemberName();
+        return this.member.getMemberEmail();
     }
 
     @Override


### PR DESCRIPTION
 ## ✅ 연관된 이슈

  > close #129

  ## 📝 작업 내용

  > AccessToken 만료 시 RefreshToken을 통해 AccessToken을 재발급할 수 있도록 백엔드 인증 흐름을 추가

  - POST /api/member/reissue API 추가
      - Refresh-Token 헤더로 RefreshToken 수신
      - 유효한 RefreshToken이면 새 AccessToken 발급
  - AccessToken 재발급 응답 DTO 추가
      - TokenReissueResDTO
      - grantType
      - accessToken
  - MemberService에 AccessToken 재발급 로직 추가
      - Bearer 토큰 형식 검증
      - RefreshToken 유효성 검증
      - RefreshToken subject 기반 회원 조회
      - 새 AccessToken 생성 후 반환
  - JwtTokenProvider에 재발급 지원 메서드 추가
      - RefreshToken에서 username 추출
      - 회원 정보 기반 AccessToken 재발급
  - JWT subject를 회원 이름이 아닌 이메일 기준으로 발급하도록 수정
      - RefreshToken 검증 및 Redis 조회 키 일관성 확보
  - JwtAuthenticationFilter에서 /api/member/reissue 인증 예외 처리 추가
  - SecurityConfig에서 회원 관련 permitAll 범위 명시화
      - /api/member/login
      - /api/member/sing-up
      - /api/member/reissue