### PR TITLE
refactor: standardize backend exception handling

### DIFF
--- a/src/main/java/com/AcovueMagazine/AboutMe/Service/AboutMeService.java
+++ b/src/main/java/com/AcovueMagazine/AboutMe/Service/AboutMeService.java
@@ -4,10 +4,11 @@ import com.AcovueMagazine.AboutMe.Dto.AboutMeReqDto;
 import com.AcovueMagazine.AboutMe.Dto.AboutMeResDto;
 import com.AcovueMagazine.AboutMe.Entity.AboutMe;
 import com.AcovueMagazine.AboutMe.Repository.AboutMeRepository;
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,16 +33,14 @@ public class AboutMeService {
         String accessToken = jwtTokenProvider.resolveToken();
 
         if (accessToken == null || accessToken.isEmpty()) {
-
-            // 추후 Custom Reaction으로 리펙토링 예정
-            throw new NullPointerException("토큰이 조회되지 않습니다.");
+            throw new RestApiException(ErrorCode.ACCESS_TOKEN_NULL);
         }
 
         // memberSeq 꺼내기
         Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
 
         if (memberSeq == null) {
-            throw new NullPointerException("해당 MemberSeq가 조회되지 않습니다.");
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
         }
 
 

--- a/src/main/java/com/AcovueMagazine/Comment/Controller/CommentController.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Controller/CommentController.java
@@ -6,9 +6,7 @@ import com.AcovueMagazine.Comment.Dto.CommentResDTO;
 import com.AcovueMagazine.Comment.Service.CommentService;
 import com.AcovueMagazine.Common.Response.ApiResponse;
 import com.AcovueMagazine.Common.Response.ResponseUtil;
-import com.AcovueMagazine.Member.Util.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -40,33 +38,27 @@ public class CommentController {
 
     // 댓글, 대댓글 등록
     @PostMapping("/create/{postId}")
-    public ApiResponse<?> createComment(@PathVariable Long postId, @RequestBody CommentReqDTO commentReqDTO, @AuthenticationPrincipal PrincipalDetails principal){
+    public ApiResponse<?> createComment(@PathVariable Long postId, @RequestBody CommentReqDTO commentReqDTO){
 
-        Long memberSeq = principal.getMemberSeq();
-
-        CommentResDTO comment = commentService.createComment(postId, commentReqDTO, memberSeq);
+        CommentResDTO comment = commentService.createComment(postId, commentReqDTO);
 
         return ResponseUtil.successResponse("댓글을 성공적으로 조회하였습니다.", comment).getBody();
     }
 
     //댓글, 대댓글 수정
     @PutMapping("/update/{postId}/{commentSeq}")
-    public ApiResponse<?> updateComment(@PathVariable Long postId, @PathVariable Long commentSeq, @RequestBody CommentReqDTO commentReqDTO, @AuthenticationPrincipal PrincipalDetails principal){
+    public ApiResponse<?> updateComment(@PathVariable Long postId, @PathVariable Long commentSeq, @RequestBody CommentReqDTO commentReqDTO){
 
-        Long memberSeq = principal.getMemberSeq();
-
-        CommentResDTO comment = commentService.updateComment(postId, commentSeq, commentReqDTO, memberSeq);
+        CommentResDTO comment = commentService.updateComment(postId, commentSeq, commentReqDTO);
 
         return ResponseUtil.successResponse("댓글을 성공적으로 수정하였습니다.",comment).getBody();
     }
 
     //댓글, 대댓글 삭제
     @DeleteMapping("/delete/{postId}/{commentSeq}")
-    public ApiResponse<?> deleteComment(@PathVariable Long postId, @PathVariable Long commentSeq, @AuthenticationPrincipal PrincipalDetails principal){
+    public ApiResponse<?> deleteComment(@PathVariable Long postId, @PathVariable Long commentSeq){
 
-        Long memberSeq = principal.getMemberSeq();
-
-        CommentResDTO comment = commentService.deleteComment(postId, commentSeq, memberSeq);
+        CommentResDTO comment = commentService.deleteComment(postId, commentSeq);
 
         return ResponseUtil.successResponse("댓글을 성공적으로 삭제하였습니다.",comment).getBody();
     }

--- a/src/main/java/com/AcovueMagazine/Comment/Service/CommentService.java
+++ b/src/main/java/com/AcovueMagazine/Comment/Service/CommentService.java
@@ -5,16 +5,17 @@ import com.AcovueMagazine.Comment.Dto.CommentResDTO;
 import com.AcovueMagazine.Comment.Entity.Comment;
 import com.AcovueMagazine.Comment.Entity.CommentStatus;
 import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Post.Repository.PostRepository;
 import com.AcovueMagazine.Member.Entity.MemberRole;
 import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Member.Repository.MembersRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final MembersRepository membersRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 댓글 + 대댓글 조회 기능
     @Transactional
@@ -35,7 +37,7 @@ public class CommentService {
 
         // 매거진 유효성 검사
         Post magazine = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         // 최초 댓글 조회
         List<Comment> topComments = commentRepository.findTopCommentsByPost(postId);
@@ -62,20 +64,19 @@ public class CommentService {
 
     // 댓글 + 대댓글 등록
     @Transactional
-    public CommentResDTO createComment(Long postId, CommentReqDTO commentReqDTO, Long memberSeq) {
+    public CommentResDTO createComment(Long postId, CommentReqDTO commentReqDTO) {
 
-        Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
+        Members members = getCurrentMember();
 
         // 매거진 유효성 검사
         Post magazine = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         Comment parentComment = null;
 
         if(commentReqDTO.getParentSeq() != null){
             parentComment = commentRepository.findById(commentReqDTO.getParentSeq())
-                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다." + commentReqDTO.getParentSeq()));
+                    .orElseThrow(() -> new RestApiException(ErrorCode.COMMENT_NOT_FOUND));
         }
 
         Comment comment = new Comment(members, magazine, commentReqDTO.getCommentContent(), parentComment);
@@ -87,24 +88,23 @@ public class CommentService {
 
     // 댓글 + 대댓글 수정
     @Transactional
-    public CommentResDTO updateComment(Long postId, Long commentSeq, CommentReqDTO commentReqDTO, Long memberSeq) {
+    public CommentResDTO updateComment(Long postId, Long commentSeq, CommentReqDTO commentReqDTO) {
 
-        // 유저 조회
-        Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. ID = " + commentReqDTO.getUserSeq()) );
+        Members members = getCurrentMember();
 
         // 매거진 조회
         Post magazine = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         // 댓글 조회
         Comment comment = commentRepository.findById(commentSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 댓글을 찾을 수 없습니다." + commentReqDTO.getCommentSeq()));
+                .orElseThrow(() -> new RestApiException(ErrorCode.COMMENT_NOT_FOUND));
 
-        // 권한 체크
-        if (!magazine.getMembers().getMemberSeq().equals(members.getMemberSeq()) &&
-                members.getMemberRole() != MemberRole.ADMIN) {
-            throw new AccessDeniedException("수정 권한이 없습니다.");
+        boolean isWriter = comment.getMember().getMemberSeq().equals(members.getMemberSeq());
+        boolean isAdmin = members.getMemberRole() == MemberRole.ADMIN;
+
+        if (!isWriter && !isAdmin) {
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
 
         // 내용 수정이 있으면 저장
@@ -117,26 +117,26 @@ public class CommentService {
 
     // 댓글 + 대댓글 삭제
     @Transactional
-    public CommentResDTO deleteComment(Long postId, Long commentSeq, Long memberSeq) {
+    public CommentResDTO deleteComment(Long postId, Long commentSeq) {
 
-        // 유저 조회
-        Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. ID = " + memberSeq) );
+        Members members = getCurrentMember();
 
         // 매거진 조회
         Post magazine = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postId));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         // 댓글 조회
         Comment comment = commentRepository.findById(commentSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 댓글을 찾을 수 없습니다." + commentSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if(comment.getMember().getMemberRole() != MemberRole.ADMIN ||
-            members.getMemberSeq() == comment.getMember().getMemberSeq()) {
-            commentRepository.delete(comment);
-        } else{
-            throw new AccessDeniedException("삭제 권한이 없습니다.");
+        boolean isWriter = comment.getMember().getMemberSeq().equals(members.getMemberSeq());
+        boolean isAdmin = members.getMemberRole() == MemberRole.ADMIN;
+
+        if (!isWriter && !isAdmin) {
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
+
+        commentRepository.delete(comment);
 
         return CommentResDTO.fromEntity(comment);
 
@@ -148,10 +148,27 @@ public class CommentService {
 
         // 포스트 조회
         postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 포스트를 찾을 수 없습니다. ID = " + postId));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         Long commentCount = commentRepository.countByPost_PostSeqAndCommentStatus(postId, CommentStatus.ACTIVE);
 
         return CommentCountResDTO.from(postId, commentCount);
+    }
+
+    private Members getCurrentMember() {
+        String accessToken = jwtTokenProvider.resolveToken();
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new RestApiException(ErrorCode.ACCESS_TOKEN_NULL);
+        }
+
+        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
+
+        if (memberSeq == null) {
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        return membersRepository.findById(memberSeq)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/AcovueMagazine/Common/Response/ErrorCode.java
+++ b/src/main/java/com/AcovueMagazine/Common/Response/ErrorCode.java
@@ -8,9 +8,26 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_EMAIL("U002", "이미 존재하는 이메일입니다.",HttpStatus.BAD_REQUEST),
+    DUPLICATE_NICKNAME("U003", "이미 존재하는 닉네임입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_PASSWORD("U004", "비밀번호가 일치하지 않습니다.",HttpStatus.BAD_REQUEST),
+    INVALID_PASSWORD_FORMAT("U005", "비밀번호는 최소 8자리 이상이며, 영문자와 숫자를 포함해야 합니다.", HttpStatus.BAD_REQUEST),
+    NO_CHANGE_REQUEST("U006", "변경된 사항이 없습니다.",HttpStatus.BAD_REQUEST),
+    INACTIVE_USER("U007", "비활성화된 사용자입니다.", HttpStatus.FORBIDDEN),
+
     ACCESS_TOKEN_NULL("T001", "토큰이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN("T002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    BAD_REQUEST("E400", "잘못 된 요청입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_REFRESH_TOKEN("T003", "유효하지 않은 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
+    REFRESH_TOKEN_NULL("T004", "RefreshToken이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+    POST_NOT_FOUND("P001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_NOT_FOUND("C001", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    S3_UPLOAD_FAILED("S001", "이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    BAD_REQUEST("E400", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN("E403", "권한이 없습니다.",  HttpStatus.FORBIDDEN),
+    INTERNAL_SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/AcovueMagazine/Common/Response/GlobalExceptionHandler.java
+++ b/src/main/java/com/AcovueMagazine/Common/Response/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package com.AcovueMagazine.Common.Response;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRestApiException(RestApiException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response = ApiResponse.ofFailure(
+                errorCode.getMessage(),
+                errorCode.getCode()
+        );
+
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e){
+        ApiResponse<Void> response = ApiResponse.ofFailure(
+                e.getMessage(),
+                ErrorCode.BAD_REQUEST.getCode()
+        );
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handlerEntityNotFoundException(EntityNotFoundException e){
+        ApiResponse<Void> response = ApiResponse.ofFailure(
+                e.getMessage(),
+                ErrorCode.USER_NOT_FOUND.getCode()
+        );
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e){
+        ApiResponse<Void> response = ApiResponse.ofFailure(
+                e.getMessage(),
+                ErrorCode.FORBIDDEN.getCode()
+        );
+
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e){
+        ApiResponse<Void> response = ApiResponse.ofFailure(
+                ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+                ErrorCode.INTERNAL_SERVER_ERROR.getCode()
+        );
+
+        return new ResponseEntity<>(response,HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/AcovueMagazine/Like/Controller/LikeController.java
+++ b/src/main/java/com/AcovueMagazine/Like/Controller/LikeController.java
@@ -7,9 +7,7 @@ import com.AcovueMagazine.Like.Dto.CommentLikeResDTO;
 import com.AcovueMagazine.Like.Dto.PostLikeCountResDTO;
 import com.AcovueMagazine.Like.Dto.PostLikeResDTO;
 import com.AcovueMagazine.Like.Service.LikeService;
-import com.AcovueMagazine.Member.Util.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,22 +19,18 @@ public class LikeController {
 
     //매거진 좋아요 토글 기능
     @PostMapping("post/{postSeq}")
-    public ApiResponse<?> togglePostLike(@PathVariable Long postSeq, @AuthenticationPrincipal PrincipalDetails principal){
+    public ApiResponse<?> togglePostLike(@PathVariable Long postSeq){
 
-        Long memberSeq = principal.getMemberSeq();
-
-        PostLikeResDTO like = likeService.togglePostLike(postSeq, memberSeq);
+        PostLikeResDTO like = likeService.togglePostLike(postSeq);
 
         return ResponseUtil.successResponse("매거진 좋아요를 성공적으로 등록/삭제하였습니다.", like).getBody();
     }
 
     //댓글 좋아요 토글 기능
     @PostMapping("comment/{commentSeq}")
-    public ApiResponse<?> toggleCommentLike(@PathVariable Long commentSeq, @AuthenticationPrincipal PrincipalDetails principal){
+    public ApiResponse<?> toggleCommentLike(@PathVariable Long commentSeq){
 
-        Long memberSeq = principal.getMemberSeq();
-
-        CommentLikeResDTO like = likeService.toggleCommentLike(commentSeq, memberSeq);
+        CommentLikeResDTO like = likeService.toggleCommentLike(commentSeq);
 
         return ResponseUtil.successResponse("댓글 좋아요를 성공적으로 등록/삭제하였습니다.", like).getBody();
     }

--- a/src/main/java/com/AcovueMagazine/Like/Service/LikeService.java
+++ b/src/main/java/com/AcovueMagazine/Like/Service/LikeService.java
@@ -2,6 +2,8 @@ package com.AcovueMagazine.Like.Service;
 
 import com.AcovueMagazine.Comment.Entity.Comment;
 import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Like.Dto.CommentLikeCountResDTO;
 import com.AcovueMagazine.Like.Dto.CommentLikeResDTO;
 import com.AcovueMagazine.Like.Dto.PostLikeCountResDTO;
@@ -14,7 +16,7 @@ import com.AcovueMagazine.Post.Entity.Post;
 import com.AcovueMagazine.Post.Repository.PostRepository;
 import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Member.Repository.MembersRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,16 +32,16 @@ public class LikeService {
     private final PostRepository magazineRepository;
     private final CommentRepository commentRepository;
     private final MembersRepository membersRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 매거진 좋아요 등록
     @Transactional
-    public PostLikeResDTO togglePostLike(Long postSeq, Long userSeq) {
+    public PostLikeResDTO togglePostLike(Long postSeq) {
 
-        Members members = membersRepository.findById(userSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다." + userSeq));
+        Members members = getCurrentMember();
 
         Post post = magazineRepository.findById(postSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다." + postSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         Optional<PostLike> existing = magazineLikeRepository.findByMembersAndPost(members, post);
 
@@ -59,13 +61,12 @@ public class LikeService {
 
     // 댓글 좋아요 토글 기능
     @Transactional
-    public CommentLikeResDTO toggleCommentLike(Long commentSeq, Long userSeq) {
+    public CommentLikeResDTO toggleCommentLike(Long commentSeq) {
 
-        Members members = membersRepository.findById(userSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다." + userSeq));
+        Members members = getCurrentMember();
 
         Comment comment = commentRepository.findById(commentSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 댓글을 찾을 수 없습니다." + commentSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.COMMENT_NOT_FOUND));
 
         Optional<CommentLike> existing = commentLikeRepository.findByMembersAndComment(members, comment);
 
@@ -104,11 +105,28 @@ public class LikeService {
     public PostLikeCountResDTO postLikeCount(Long postSeq) {
 
         Post magazine = magazineRepository.findById(postSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다." + postSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         Long magazineLikeCount = magazineLikeRepository.countByPost_PostSeq(postSeq);
 
         return PostLikeCountResDTO.from(postSeq, magazineLikeCount);
 
+    }
+
+    private Members getCurrentMember() {
+        String accessToken = jwtTokenProvider.resolveToken();
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new RestApiException(ErrorCode.ACCESS_TOKEN_NULL);
+        }
+
+        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
+
+        if (memberSeq == null) {
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        return membersRepository.findById(memberSeq)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/AcovueMagazine/Member/Controller/MemberController.java
+++ b/src/main/java/com/AcovueMagazine/Member/Controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.AcovueMagazine.Member.Controller;
 
 import com.AcovueMagazine.Common.Response.ApiResponse;
-import com.AcovueMagazine.Common.Response.ErrorCode;
 import com.AcovueMagazine.Common.Response.ResponseUtil;
 import com.AcovueMagazine.Member.Dto.MemberDataDto;
 import com.AcovueMagazine.Member.Dto.MemberLoginDto;
@@ -9,11 +8,8 @@ import com.AcovueMagazine.Member.Dto.MemberSignUpDto;
 import com.AcovueMagazine.Member.Dto.MemberUpdateDto;
 import com.AcovueMagazine.Member.Entity.MemberStatus;
 import com.AcovueMagazine.Member.Entity.Members;
-import com.AcovueMagazine.Member.Repository.MembersRepository;
 import com.AcovueMagazine.Member.Service.MemberService;
-import com.AcovueMagazine.Member.Util.JwtTokenProvider;
-import com.AcovueMagazine.Member.Util.MemberDetail;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -22,17 +18,11 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/member")
+@RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
-    private final MembersRepository membersRepository;
-    private final JwtTokenProvider jwtTokenProvider;
 
-    public MemberController(MemberService memberService, MembersRepository membersRepository, JwtTokenProvider jwtTokenProvider) {
-        this.memberService = memberService;
-        this.membersRepository = membersRepository;
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<MemberLoginDto.TokenResDto> login(@RequestBody Map<String, String> loginForm){
@@ -44,20 +34,7 @@ public class MemberController {
     // 로그아웃
     @PutMapping("/logout")
     public ResponseEntity<?> logout(Authentication authentication){
-        Object principal = authentication.getPrincipal();
-        Long memberSeq = null;
-        String email;
-
-        if (principal instanceof MemberDetail memberDetail){
-            email = memberDetail.getUsername();
-            memberSeq = memberDetail.getMember().getMemberSeq();
-        } else if (principal instanceof org.springframework.security.core.userdetails.User user){
-            email = user.getUsername();
-        }else{
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 정보가 없습니다.");
-        }
-
-        memberService.logout(authentication, memberSeq, email);
+        memberService.logout(authentication);
 
         return ResponseEntity.ok("로그아웃이 성공적으로 완료되었습니다.");
     }
@@ -74,43 +51,16 @@ public class MemberController {
     @PutMapping("/me/deactivate")
     public ApiResponse<?> deactivate(Authentication authentication){
 
-        String accessToken = jwtTokenProvider.resolveToken();
+        MemberStatus memberStatus = memberService.inActivateCurrentUser();
 
-        if (accessToken == null) {
-            return ResponseUtil.failureResponse("토큰 정보가 없습니다.", ErrorCode.INVALID_TOKEN.getCode(), HttpStatus.UNAUTHORIZED).getBody();
-        }
-
-        // memberSeq 꺼내기
-        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
-
-        if (memberSeq == null) {
-            return ResponseUtil.failureResponse("회원 정보를 확인할 수 없습니다.", ErrorCode.USER_NOT_FOUND.getCode(), HttpStatus.BAD_REQUEST).getBody();
-        }
-
-        // 비활성화 처리
-        memberService.inActivateUser(memberSeq);
-
-        return ResponseUtil.successResponse("성공적으로 회원 상태가 비활성화 되었습니다.", memberSeq).getBody();
+        return ResponseUtil.successResponse("성공적으로 회원 상태가 비활성화 되었습니다.", memberStatus).getBody();
     }
 
     // 회원 내 정보 조회
     @GetMapping("/me")
     public ApiResponse<?> getUserData(Authentication authentication){
 
-        String accessToken = jwtTokenProvider.resolveToken();
-
-        if (accessToken == null) {
-            return ResponseUtil.failureResponse("토큰 정보가 없습니다.", ErrorCode.INVALID_TOKEN.getCode(), HttpStatus.UNAUTHORIZED).getBody();
-        }
-
-        // memberSeq 꺼내기
-        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
-
-        if (memberSeq == null) {
-            return ResponseUtil.failureResponse("회원 정보를 확인할 수 없습니다.", ErrorCode.USER_NOT_FOUND.getCode(), HttpStatus.BAD_REQUEST).getBody();
-        }
-
-        MemberDataDto member = memberService.getMemberData(memberSeq);
+        MemberDataDto member = memberService.getCurrentMemberData();
 
         return ResponseUtil.successResponse("마이페이지, 내 정보 조회를 성공적으로 수행하였습니다.", member).getBody();
     }
@@ -120,28 +70,14 @@ public class MemberController {
     @PutMapping("/me/update")
     public ApiResponse<?> userDataUpdate(Authentication authentication, @RequestBody MemberUpdateDto memberUpdateDto){
 
-        String accessToken = jwtTokenProvider.resolveToken();
-
-        if (accessToken == null) {
-            return ResponseUtil.failureResponse("토큰 정보가 없습니다.", ErrorCode.INVALID_TOKEN.getCode(), HttpStatus.UNAUTHORIZED).getBody();
-        }
-
-        // memberSeq 꺼내기
-        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
-
-        if (memberSeq == null) {
-            return ResponseUtil.failureResponse("회원 정보를 확인할 수 없습니다.", ErrorCode.USER_NOT_FOUND.getCode(), HttpStatus.BAD_REQUEST).getBody();
-        }
-
-        Members members = memberService.updateMemberData(memberSeq, memberUpdateDto);
+        Members members = memberService.updateCurrentMemberData(memberUpdateDto);
 
         return ResponseUtil.successResponse("성공적으로 회원 정보 변경이 완료되었습니다.", members).getBody();
     }
 
     // access token 만료 후 refreshToken 발급 -> accessToken 재발급으로 이어지는 기능
     @PostMapping("/reissue")
-    public ApiResponse<?> reissue(@RequestHeader("Refresh-Token")
-                                     String refreshTokenHeader){
+    public ApiResponse<?> reissue(@RequestHeader("Refresh-Token") String refreshTokenHeader){
         MemberLoginDto.TokenReissueResDTO response = memberService.reissueAccessToken(refreshTokenHeader);
 
         return ResponseUtil.successResponse("성공적으로 accessToken이 재 발급 되었습니다.", response).getBody();

--- a/src/main/java/com/AcovueMagazine/Member/Service/MemberService.java
+++ b/src/main/java/com/AcovueMagazine/Member/Service/MemberService.java
@@ -1,7 +1,7 @@
 package com.AcovueMagazine.Member.Service;
 
 import com.AcovueMagazine.Common.Response.ErrorCode;
-import com.AcovueMagazine.Common.Response.ResponseUtil;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Member.Dao.RedisDao;
 import com.AcovueMagazine.Member.Dto.MemberDataDto;
 import com.AcovueMagazine.Member.Dto.MemberLoginDto;
@@ -13,17 +13,15 @@ import com.AcovueMagazine.Member.Entity.MemberStatus;
 import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Member.Repository.MembersRepository;
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
-import jakarta.persistence.EntityNotFoundException;
+import com.AcovueMagazine.Member.Util.MemberDetail;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.lang.reflect.Member;
 import java.time.Duration;
 
 @Service
@@ -42,15 +40,15 @@ public class MemberService {
 
         // 이메일 중복 체크
         if (membersRepository.existsByMemberEmail(memberSignUpDto.getMemberEmail())){
-            throw new IllegalArgumentException("이미 존재하는 이메일 입니다.");
+            throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
         }
         // 닉네임 중복 체크
         if (membersRepository.existsByMemberNickname(memberSignUpDto.getMemberNickname())){
-            throw new IllegalArgumentException("이미 존재하는 닉네임 입니다.");
+            throw new RestApiException(ErrorCode.DUPLICATE_NICKNAME);
         }
         // 비밀번호 최소 자리수, 영문, 숫자 혼합했는지 체크
         if (!isValidPassword(memberSignUpDto.getMemberPassword())) {
-            throw new IllegalArgumentException("비밀번호는 최소 8자리 이상이며, 영문자와 숫자를 포함해야 합니다.");
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_FORMAT);
         }
 
         // 비밀번호 암호화
@@ -77,19 +75,14 @@ public class MemberService {
     // 회원 로그인
     public MemberLoginDto.TokenResDto login(String memberEmail, String memberPassword) {
 
-        System.out.println(">>> 로그인 시도: " + memberEmail);
-
         // DB에서 회원을 조회
         Members member = membersRepository.findByMemberEmail(memberEmail)
-                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
-        System.out.println(">>> 회원 조회 완료, DB 비밀번호: " + member.getMemberPassword());
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         // 비번 검증
         boolean matches = passwordEncoder.matches(memberPassword, member.getMemberPassword());
-        System.out.println(">>> 입력 비밀번호와 DB 비밀번호 비교: " + matches);
         if (!matches) {
-            System.out.println(">>> 비밀번호 불일치");
-            throw new RuntimeException("비밀번호가 일치하지 않습니다");
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD);
         }
 //        String encodedPassword = passwordEncoder.encode(memberPassword);
 
@@ -98,11 +91,8 @@ public class MemberService {
                 new UsernamePasswordAuthenticationToken(memberEmail, memberPassword);
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        System.out.println(">>> Authentication 생성 완료" + authentication.isAuthenticated());
-
         //검증 된 정보로 토큰 생성
         MemberLoginDto.TokenResDto jwtToken = jwtTokenProvider.generateToken(authentication);
-        System.out.println(">>> jwtToken: " + jwtToken);
 
         return jwtToken;
     }
@@ -116,7 +106,8 @@ public class MemberService {
 
 
     // 회원 로그아웃
-    public void logout(Authentication authentication, Long memberSeq, String email) {
+    public void logout(Authentication authentication) {
+        String email = getEmailFromAuthentication(authentication);
 
         // redis refreshtoken delete
         jwtTokenProvider.deleteRefreshToken(email);
@@ -142,11 +133,29 @@ public class MemberService {
         }
     }
 
+    private String getEmailFromAuthentication(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof MemberDetail memberDetail) {
+            return memberDetail.getUsername();
+        }
+
+        if (principal instanceof User user) {
+            return user.getUsername();
+        }
+
+        throw new RestApiException(ErrorCode.INVALID_TOKEN);
+    }
+
     // 회원 탈퇴 ( 회원 비활성화 )
     public MemberStatus inActivateUser(Long memberSeq) {
 
         Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         // 회원 계정 상태 Active -> IeActive
         members.inActivate();
@@ -158,7 +167,7 @@ public class MemberService {
     // 회원 정보 변경 (비밀번호, 닉네임)
     public Members updateMemberData(Long memberSeq, MemberUpdateDto memberUpdateDto) {
 
-        Members member = membersRepository.findById(memberSeq).orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+        Members member = membersRepository.findById(memberSeq).orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         boolean changed = false;
 
@@ -168,7 +177,7 @@ public class MemberService {
                     .orElse(null);
 
             if (existingNickName != null && !existingNickName.getMemberSeq().equals(memberSeq)) {
-                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+                throw new RestApiException(ErrorCode.DUPLICATE_NICKNAME);
             }
 
             member.updateNickname(memberUpdateDto.getMemberNickname());
@@ -182,11 +191,11 @@ public class MemberService {
 
             // 현재 비밀번호 일치 여부 체크
             if (!passwordEncoder.matches(memberUpdateDto.getMemberPassword(), member.getMemberPassword())) {
-                throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+                throw new RestApiException(ErrorCode.INVALID_PASSWORD);
             }
 
             if (!isValidPassword(memberUpdateDto.getMemberChangePassword())) {
-                throw new IllegalArgumentException("비밀번호는 최소 8자리 이상이며, 영문자와 숫자를 포함해야 합니다.");
+                throw new RestApiException(ErrorCode.INVALID_PASSWORD_FORMAT);
             }
 
             // 새 비밀번호 암호화하여 저장
@@ -197,7 +206,7 @@ public class MemberService {
         }
 
         if (!changed) {
-            throw new IllegalArgumentException("변경 된 사항이 없습니다.");
+            throw new RestApiException(ErrorCode.NO_CHANGE_REQUEST);
         }
 
         return member;
@@ -208,27 +217,58 @@ public class MemberService {
     public MemberDataDto getMemberData(Long memberSeq) {
 
         Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         return MemberDataDto.from(members);
+    }
+
+    public MemberStatus inActivateCurrentUser() {
+        Long memberSeq = getCurrentMemberSeq();
+        return inActivateUser(memberSeq);
+    }
+
+    public MemberDataDto getCurrentMemberData() {
+        Long memberSeq = getCurrentMemberSeq();
+        return getMemberData(memberSeq);
+    }
+
+    public Members updateCurrentMemberData(MemberUpdateDto memberUpdateDto) {
+        Long memberSeq = getCurrentMemberSeq();
+        return updateMemberData(memberSeq, memberUpdateDto);
+    }
+
+    private Long getCurrentMemberSeq() {
+        String accessToken = jwtTokenProvider.resolveToken();
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new RestApiException(ErrorCode.ACCESS_TOKEN_NULL);
+        }
+
+        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
+
+        if (memberSeq == null) {
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        return memberSeq;
     }
 
     //accessToken 재발급
     public MemberLoginDto.TokenReissueResDTO reissueAccessToken(String refreshTokenHeader) {
 
         if(refreshTokenHeader == null || !refreshTokenHeader.startsWith("Bearer ")){
-            throw new IllegalArgumentException("RefreshToken 형식이 올바르지 않습니다.");
+            throw new RestApiException(ErrorCode.REFRESH_TOKEN_NULL);
         }
 
         String refreshToken = refreshTokenHeader.substring(7);
 
         if(!jwtTokenProvider.validateRefreshToken(refreshToken)){
-            throw new IllegalArgumentException("유효하지 않은 RefreshToken 입니다.");
+            throw new RestApiException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         String email = jwtTokenProvider.getUsernameFromRefreshToken(refreshToken);
 
-        Members member = membersRepository.findByMemberEmail(email).orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+        Members member = membersRepository.findByMemberEmail(email).orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         String newAccessToken = jwtTokenProvider.reissueAccessToken(member);
 

--- a/src/main/java/com/AcovueMagazine/Member/Util/JwtTokenProvider.java
+++ b/src/main/java/com/AcovueMagazine/Member/Util/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.AcovueMagazine.Member.Util;
 
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Member.Dao.RedisDao;
 import com.AcovueMagazine.Member.Dto.MemberLoginDto;
 import com.AcovueMagazine.Member.Entity.Members;
@@ -69,9 +71,9 @@ public class JwtTokenProvider {
             username = memberDetail.getMember().getMemberEmail();
             memberSeq = memberDetail.getMember().getMemberSeq();
         } else if(principal instanceof User user){
-            throw new IllegalArgumentException("MemberSeq를 가져올 수 없습니다.");
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
         } else{
-            throw new IllegalArgumentException("알 수 없는 principal 타입");
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
         }
 
         //AccessToken 생성
@@ -118,7 +120,7 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(accessToken);
 
         if(claims.get("auth") == null){
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
         }
 
         //Claim에 있는 정보 가져오기
@@ -208,7 +210,7 @@ public class JwtTokenProvider {
     //RefreshToken 삭제
     public void deleteRefreshToken(String username) {
         if(username == null || username.isEmpty()){
-            throw new IllegalArgumentException("username cannot be null or empty");
+            throw new RestApiException(ErrorCode.USER_NOT_FOUND);
         }
 
         // 로그아웃 시 redis.dao에서 refreshTOken 삭제

--- a/src/main/java/com/AcovueMagazine/Member/Util/SecurityUtil.java
+++ b/src/main/java/com/AcovueMagazine/Member/Util/SecurityUtil.java
@@ -1,5 +1,7 @@
 package com.AcovueMagazine.Member.Util;
 
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -10,7 +12,7 @@ public class SecurityUtil {
         // 현재 실행 중인 스레드에 저장했던 인증 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication==null || authentication.getName() == null){
-            throw new RuntimeException("no authentication information");
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
         }
 
         return authentication.getName();

--- a/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
+++ b/src/main/java/com/AcovueMagazine/Post/Controller/PostController.java
@@ -3,7 +3,6 @@ package com.AcovueMagazine.Post.Controller;
 
 import com.AcovueMagazine.Common.Response.ApiResponse;
 import com.AcovueMagazine.Common.Response.ResponseUtil;
-import com.AcovueMagazine.Member.Util.PrincipalDetails;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
 import com.AcovueMagazine.Post.Dto.PostResDto;
 import com.AcovueMagazine.Post.Entity.CommunityCategory;
@@ -12,7 +11,6 @@ import com.AcovueMagazine.Post.Service.PostService;
 import com.AcovueMagazine.Post.Service.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -90,8 +88,8 @@ public class PostController {
 
     // 매거진 삭제
     @DeleteMapping("/delete/{postSeq}")
-    public ApiResponse<?> deletePost(@PathVariable Long postSeq, @AuthenticationPrincipal PrincipalDetails principal) {
-        PostResDto magazine = postService.deletePost(postSeq, principal.getMemberSeq());
+    public ApiResponse<?> deletePost(@PathVariable Long postSeq) {
+        PostResDto magazine = postService.deletePost(postSeq);
 
         return ResponseUtil.successResponse("매거진 삭제를 성공적으로 수행하였습니다", magazine).getBody();
     }
@@ -99,17 +97,13 @@ public class PostController {
     // S3 사진 업로드
     @PostMapping("/image")
     public ApiResponse<?> uploadImage(@RequestParam("image")MultipartFile image) {
-        try{
-            // S3 업로드 > URL 리턴
-            String imageUrl = s3UploadService.saveFile(image);
+        // S3 업로드 > URL 리턴
+        String imageUrl = s3UploadService.saveFile(image);
 
-            Map<String, String> data = new HashMap<>();
-            data.put("imageUrl", imageUrl);
+        Map<String, String> data = new HashMap<>();
+        data.put("imageUrl", imageUrl);
 
-            return ResponseUtil.successResponse("S3 이미지 업로드를 성공적으로 수행하였습니다.", data).getBody();
-        }catch (Exception e){
-            throw new RuntimeException("S3 이미지 업로드 도중 오류가 발생하였습니다.: " + e.getMessage());
-        }
+        return ResponseUtil.successResponse("S3 이미지 업로드를 성공적으로 수행하였습니다.", data).getBody();
 
     }
 

--- a/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
+++ b/src/main/java/com/AcovueMagazine/Post/Service/PostService.java
@@ -2,6 +2,8 @@ package com.AcovueMagazine.Post.Service;
 
 import com.AcovueMagazine.Comment.Entity.CommentStatus;
 import com.AcovueMagazine.Comment.Respository.CommentRepository;
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.AcovueMagazine.Like.Respository.PostLikeRepository;
 import com.AcovueMagazine.Member.Util.JwtTokenProvider;
 import com.AcovueMagazine.Post.Dto.PostReqDto;
@@ -13,7 +15,6 @@ import com.AcovueMagazine.Member.Entity.Members;
 import com.AcovueMagazine.Member.Entity.MemberStatus;
 import com.AcovueMagazine.Member.Repository.MembersRepository;
 import com.AcovueMagazine.Post.Specification.PostSpecification;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -122,10 +122,10 @@ public class PostService {
     @Transactional
     public PostResDto getPost(Long postSeq) {
         Post post = postRepository.findByPostSeqAndPostStatus(postSeq, PostStatus.ACTIVE)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
         if (post.getMembers().getMemberStatus() == MemberStatus.INACTIVE) {
-            throw new IllegalStateException("비활성화된 유저입니다.");
+            throw new RestApiException(ErrorCode.INACTIVE_USER);
         }
 
         return PostResDto.fromEntity(post);
@@ -135,28 +135,12 @@ public class PostService {
     @Transactional
     public PostResDto createPost(PostReqDto postReqDTO) {
 
-        String accessToken = jwtTokenProvider.resolveToken();
-
-        if (accessToken == null || accessToken.isEmpty()) {
-
-            // 추후 Custom Reaction으로 리펙토링 예정
-            throw new NullPointerException("토큰이 조회되지 않습니다.");
-        }
-
-        // memberSeq 꺼내기
-        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
-
-        if (memberSeq == null) {
-            throw new NullPointerException("해당 MemberSeq가 조회되지 않습니다.");
-        }
-
-        Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
+        Members members = getCurrentMember();
 
         boolean requestedNotice = Boolean.TRUE.equals(postReqDTO.getNotice());
 
         if(requestedNotice && members.getMemberRole() != MemberRole.ADMIN){
-            throw new AccessDeniedException("공지 작성 권한이 없습니다.");
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
 
         Post post = new Post(
@@ -189,36 +173,20 @@ public class PostService {
     @Transactional
     public PostResDto updatePost(PostReqDto postReqDTO, Long postSeq) {
 
-        String accessToken = jwtTokenProvider.resolveToken();
-
-        if (accessToken == null || accessToken.isEmpty()) {
-
-            // 추후 Custom Reaction으로 리펙토링 예정
-            throw new NullPointerException("토큰이 조회되지 않습니다.");
-        }
-
-        // memberSeq 꺼내기
-        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
-
-        if (memberSeq == null) {
-            throw new NullPointerException("해당 MemberSeq가 조회되지 않습니다.");
-        }
-
         Post post = postRepository.findById(postSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. ID = " + postSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
-        Members members = membersRepository.findById(memberSeq)
-                .orElseThrow(()-> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
+        Members members = getCurrentMember();
 
         boolean isWriter = post.getMembers().getMemberSeq().equals(members.getMemberSeq());
         boolean isAdmin = (members.getMemberRole() == MemberRole.ADMIN);
 
         if (!isWriter && !isAdmin) {
-            throw new AccessDeniedException("수정 권한이 없습니다.");
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
 
         if (postReqDTO.getNotice() != null && !isAdmin){
-            throw new AccessDeniedException("공지 수정 권한이 없습니다.");
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
 
         // 제목 수정이 있으면 저장
@@ -249,25 +217,41 @@ public class PostService {
 
     // 게시글 삭제 기능
     @Transactional
-    public PostResDto deletePost(Long postSeq, Long memberSeq) {
+    public PostResDto deletePost(Long postSeq) {
 
         Post post = postRepository.findById(postSeq)
-                .orElseThrow(() -> new EntityNotFoundException("해당 매거진을 찾을 수 없습니다. POST_ID = " + postSeq));
+                .orElseThrow(() -> new RestApiException(ErrorCode.POST_NOT_FOUND));
 
-        Members currentMember = membersRepository.findById(memberSeq)
-                .orElseThrow( () -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. USER_ID = " + memberSeq));
+        Members currentMember = getCurrentMember();
 
         boolean isWrtter = post.getMembers().getMemberSeq().equals(currentMember.getMemberSeq());
         boolean isAdmin = currentMember.getMemberRole() == MemberRole.ADMIN;
 
         if(!isWrtter && !isAdmin){
-            throw new AccessDeniedException("삭제 권한이 없습니다.");
+            throw new RestApiException(ErrorCode.FORBIDDEN);
         }
 
         // 게시물 소프트 삭제
         post.inActivate();
 
         return PostResDto.fromEntity(post);
+    }
+
+    private Members getCurrentMember() {
+        String accessToken = jwtTokenProvider.resolveToken();
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new RestApiException(ErrorCode.ACCESS_TOKEN_NULL);
+        }
+
+        Long memberSeq = jwtTokenProvider.getMemberSeqFromToken(accessToken);
+
+        if (memberSeq == null) {
+            throw new RestApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        return membersRepository.findById(memberSeq)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
     }
 
     // 게시물 검색 기능

--- a/src/main/java/com/AcovueMagazine/Post/Service/S3UploadService.java
+++ b/src/main/java/com/AcovueMagazine/Post/Service/S3UploadService.java
@@ -1,6 +1,7 @@
 package com.AcovueMagazine.Post.Service;
 
-import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.AcovueMagazine.Common.Response.ErrorCode;
+import com.AcovueMagazine.Common.Response.RestApiException;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +24,7 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String saveFile(MultipartFile multipartFile) throws IOException {
+    public String saveFile(MultipartFile multipartFile) {
 
         String originalFilename = multipartFile.getOriginalFilename();
 
@@ -35,8 +36,12 @@ public class S3UploadService {
         metadata.setContentLength(multipartFile.getSize());
         metadata.setContentType(multipartFile.getContentType());
 
-        // S3로 전송, PublicRead 권한 부여
-        amazonS3.putObject(new PutObjectRequest(bucket, uniqueFileName, multipartFile.getInputStream(), metadata));
+        try {
+            // S3로 전송, PublicRead 권한 부여
+            amazonS3.putObject(new PutObjectRequest(bucket, uniqueFileName, multipartFile.getInputStream(), metadata));
+        } catch (IOException e) {
+            throw new RestApiException(ErrorCode.S3_UPLOAD_FAILED);
+        }
 
         // S3 올린 파일 URL 꺼내서 반환
         return amazonS3.getUrl(bucket, uniqueFileName).toString();
@@ -46,13 +51,8 @@ public class S3UploadService {
         List<String> imageUrls = new ArrayList<>();
 
         for (MultipartFile file : multipartFiles) {
-            try{
-                String url = saveFile(file);
-                imageUrls.add(url);
-            } catch (IOException e){
-                throw new RuntimeException("S3 다중 이미지 업로드에 실패하였습니다.", e);
-
-            }
+            String url = saveFile(file);
+            imageUrls.add(url);
         }
         return imageUrls;
     }


### PR DESCRIPTION
## ✅ 연관된 이슈

  > close #131

  ## 📝 작업 내용

  - 백엔드 예외 응답 통일을 위한 GlobalExceptionHandler 추가
  - 공통 ErrorCode를 확장하여 회원, 토큰, 게시글, 댓글, S3 업로드 예외
    코드 정리
  - 기존 IllegalArgumentException, EntityNotFoundException,
    AccessDeniedException, RuntimeException 기반 예외를 RestApiException
    기반으로 정리
  - Member, Post, Comment, Like, AboutMe, S3Upload 관련 서비스 예외 처리
    방식 통일
  - 컨트롤러에서 직접 토큰/회원 식별값을 파싱하던 로직을 서비스 계층으로
    이동
  - MemberController, PostController, CommentController, LikeController
    를 요청 처리 중심으로 정리
  - 댓글 수정/삭제 권한 검증을 댓글 작성자 또는 관리자 기준으로 보정
  - 이미지 업로드 실패 시 공통 예외 응답으로 처리되도록 수정